### PR TITLE
Allow contributors to use their favourite editor by allowing soft wrapped lines

### DIFF
--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -9,7 +9,7 @@ rule 'MD003', :style => :atx
 # Only allow dashes in unordered lists
 rule 'MD004', :style => :dash
 
-# Do not enforce line length to make it easier to cut and paste content from other editors.
+# Do not enforce line length
 exclude_rule 'MD013'
 
 # Ignore blockquotes separated only be a blank line. This is a limitation of

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -9,8 +9,8 @@ rule 'MD003', :style => :atx
 # Only allow dashes in unordered lists
 rule 'MD004', :style => :dash
 
-# Enforce line length of 80 characters except in code blocks and tables
-rule 'MD013', :code_blocks => false, :tables => false
+# Do not enforce line length to make it easier to cut and paste content from other editors.
+exclude_rule 'MD013'
 
 # Ignore blockquotes separated only be a blank line. This is a limitation of
 # some markdown parsers, not markdown itself.

--- a/content/docs/contributing/advanced.md
+++ b/content/docs/contributing/advanced.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Advanced"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 6
+weight: 7
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/contributing/contributing_changes.md
+++ b/content/docs/contributing/contributing_changes.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Contributing Changes"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 4
+weight: 5
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/contributing/creating_a_page.md
+++ b/content/docs/contributing/creating_a_page.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Adding New Content"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 2
+weight: 3
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/contributing/editing_a_page.md
+++ b/content/docs/contributing/editing_a_page.md
@@ -142,10 +142,10 @@ Shortcodes can be included in the handbooks repository. For more information see
 Create a link to a file or directory in the handbook's repository.
 
 ```markdown
-{{%/* repo_link target="README.md" text="README" */%}}
+{{%/* repo_link path="README.md" text="README" */%}}
 ```
 
-`target`
+`path`
 : Path to the file or directory relative to the root of the repository
 
 `text`

--- a/content/docs/contributing/editing_a_page.md
+++ b/content/docs/contributing/editing_a_page.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Editing a Page"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 3
+weight: 4
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/contributing/reviewing_changes.md
+++ b/content/docs/contributing/reviewing_changes.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Reviewing Changes"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 5
+weight: 6
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/contributing/style_guide.md
+++ b/content/docs/contributing/style_guide.md
@@ -13,11 +13,9 @@ weight: 2
 
 # Style Guide
 
-## Markdown
-
 ## Semantic Line Breaks
 
-It is strongly encouraged to use [Semantic Line Breaks](https://sembr.org/) when writing for the handbook.
+It is encouraged to use [Semantic Line Breaks](https://sembr.org/) when writing for the handbook.
 This improves the readability of source files and make diffs clearer.
 The Semantic Line Breaks [specification](https://sembr.org) explains the rules and reasoning.
 The most important rules are
@@ -25,3 +23,12 @@ The most important rules are
 > - A semantic line break MUST occur after a sentence, as punctuated by a period (.), exclamation mark (!), or question mark (?).
 > - A semantic line break SHOULD occur after an independent clause as punctuated by a comma (,), semicolon (;), colon (:), or em dash (—).
 > - A semantic line break MAY occur after a dependent clause in order to clarify grammatical structure or satisfy line length constraints.
+
+## Markdown
+
+Whenever possible, the handbook's prose should be written in Markdown rather than HTML.
+However, it is completely reasonable use HTML when it is needed.
+When it is advantageous, data should be [stored in data files and processed using shortcodes](https://gohugo.io/templates/data-templates/) rather than presented in raw Markdown.
+
+Markdown styling is enforced by [markdownlint](https://github.com/markdownlint/markdownlint) using the configuration {{% repo_link path=".mdl_style.rb" text=".mdl_style.rb" %}}.
+An explanation of the rules can be found [here](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md).

--- a/content/docs/contributing/style_guide.md
+++ b/content/docs/contributing/style_guide.md
@@ -18,7 +18,7 @@ weight: 2
 It is encouraged to use [Semantic Line Breaks](https://sembr.org/) when writing for the handbook.
 This improves the readability of source files and make diffs clearer.
 The Semantic Line Breaks [specification](https://sembr.org) explains the rules and reasoning.
-The most important rules are
+The most important rules are,
 
 > - A semantic line break MUST occur after a sentence, as punctuated by a period (.), exclamation mark (!), or question mark (?).
 > - A semantic line break SHOULD occur after an independent clause as punctuated by a comma (,), semicolon (;), colon (:), or em dash (—).

--- a/content/docs/contributing/style_guide.md
+++ b/content/docs/contributing/style_guide.md
@@ -1,0 +1,27 @@
+---
+# Page title as it appears in the navigation menu
+title: "Style Guide"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 2
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exlude this page from the search
+# bookSearchExclude = true
+---
+
+# Style Guide
+
+## Markdown
+
+## Semantic Line Breaks
+
+It is strongly encouraged to use [Semantic Line Breaks](https://sembr.org/) when writing for the handbook.
+This improves the readability of source files and make diffs clearer.
+The Semantic Line Breaks [specification](https://sembr.org) explains the rules and reasoning.
+The most important rules are
+
+> - A semantic line break MUST occur after a sentence, as punctuated by a period (.), exclamation mark (!), or question mark (?).
+> - A semantic line break SHOULD occur after an independent clause as punctuated by a comma (,), semicolon (;), colon (:), or em dash (—).
+> - A semantic line break MAY occur after a dependent clause in order to clarify grammatical structure or satisfy line length constraints.


### PR DESCRIPTION
## Summary
Allow contributors to use their favourite editor by allowing soft wrapped lines.

For me (and possibly others) my favourite code editor and my favourite prose editor are very different. Writing _good quality_ prose in a code editor is unnecessarily difficult. For editing prose, my top priority is a really good, interactive spelling and grammar checker. For longer edits, I would add proportional width fonts to my requirements.

For short edits, editing in the browser with the Grammarly extension fulfils this. However, there are no linter hints in the browser, counting line length manually is impractical and waiting for CI feedback is slow for a quick edit.

For longer edits, this means cutting and pasting content into another editor**  to work on and then cutting and pasting it back when it is complete.

** For me this means something supported by Grammarly; Google Docs, OpenOffice, Joplin, dare I say it even Word, are all better alternatives for editing prose than code editors.

Some grammar checkers don't handle text with hard line breaks (they treat the text as bullet points in this case). This means removing all of the hardline breaks and putting them back in after editing.

This PR removes one of the barriers to contributing.

## Related issues
Related to comments made in this discussion:
https://github.com/alan-turing-institute/REG-handbook/discussions/10#discussioncomment-2488604

## Screenshots
None

### Updates

