### PR TITLE
Add basic pre-commit config

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,2 @@
+style '.mdl_style.rb'
+ignore_front_matter true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-xml
+    -   id: check-json
+    -   id: pretty-format-json
+        args: [--no-ensure-ascii, --no-sort-keys, --autofix]
+        files: ".+json"
+    -   id: check-added-large-files
+# - repo: https://github.com/jumanjihouse/pre-commit-hooks
+#   rev: master  # or specific git tag
+#   hooks:
+#     - id: markdownlint # Configure in .mdlrc
+#       files: "content/"

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,6 +1,10 @@
 {
-    "ignorePatterns": [
-        {"pattern": "^https://github.com/alan-turing-institute/research-engineering-group"},
-        {"pattern": "^https://docs.github.com"}
-    ]
+  "ignorePatterns": [
+    {
+      "pattern": "^https://github.com/alan-turing-institute/research-engineering-group"
+    },
+    {
+      "pattern": "^https://docs.github.com"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
The PR:
* Adds a basic pre-commit config, which
  * strips trailing whitespace and fixes a single blank line at the end of files.
  * Check the syntax of yaml, XML and json files.

TBC: Adds notes on testing markdown lniting locally with `markdownlint`.

## Related issues
I have opted not to enforce markdownlinting via pre-commit. This is to allow people to focus on the content without worrying about markdown linting rules until they are ready to merge.

## Screenshots

### Updates
<!--
Please update this initial comment with important updates (e.g. decisions taken).
-->
