### PR TITLE
Update markdownlint advice

### DIFF
--- a/content/docs/contributing/getting_started.md
+++ b/content/docs/contributing/getting_started.md
@@ -21,15 +21,9 @@ To contribute to the handbook you will need
 - [Hugo](https://gohugo.io/getting-started/installing/) (You will need the
   extended version with Sass/SCSS support)
 - Your favourite text editor
-
-{{% hint info %}}
-You might also find it helpful to install
-[markdownlint](https://github.com/markdownlint/markdownlint) so that you can
-lint your branch before making a pull request.
-
-The linting style used is included in the root of the repository,
-`.mdl_style.rb`.
-{{% /hint %}}
+- Optionally [markdownlint](https://github.com/markdownlint/markdownlint);
+  see the [Style Guide]({{< relref "/docs/contributing/style_guide.md#style-enforcement" >}})
+  for more details.
 
 ## Clone the repository
 

--- a/content/docs/contributing/style_guide.md
+++ b/content/docs/contributing/style_guide.md
@@ -30,5 +30,26 @@ Whenever possible, the handbook's prose should be written in Markdown rather tha
 However, it is completely reasonable use HTML when it is needed.
 When it is advantageous, data should be [stored in data files and processed using shortcodes](https://gohugo.io/templates/data-templates/) rather than presented in raw Markdown.
 
+## Style Enforcement
+
 Markdown styling is enforced by [markdownlint](https://github.com/markdownlint/markdownlint) using the configuration {{% repo_link path=".mdl_style.rb" text=".mdl_style.rb" %}}.
 An explanation of the rules can be found [here](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md).
+
+You can optionally install markdownlint locally to check your changes before submitting a pull request.
+
+{{% hint info %}}
+Make sure you install the Ruby version (`mdl`) and not the Node.js version (`markdownlint-cli`) contained in the homebrew repositories,
+since the configuration is only good for the former.
+{{% /hint %}}
+
+Once installed and assuming you're in the repository root, you can lint a specific file you've made changes to like this:
+
+```bash
+mdl -s .mdl_style.rb <filename>
+```
+
+Alternatively run it over the entire handbook content like this:
+
+```bash
+mdl -s .mdl_style.rb ./content
+```


### PR DESCRIPTION
## Summary

I hit some issues installing and running markdownlint on the handbook content, so updated the text to try to help others avoid the same pitfalls:

1. Make clear that the Ruby version of markdownlint is the one that should be used.
2. Provide simple examples for running markdownlint against the content.

## Related issues

N/A

## Screenshots

N/A

### Updates
