### PR TITLE
Update Project tracker columns to emoji

### DIFF
--- a/content/docs/onboarding/new_joiners/first_few_days.md
+++ b/content/docs/onboarding/new_joiners/first_few_days.md
@@ -127,8 +127,9 @@ to add you to the relevant mailing list.
 If you've done all the above, read through the handbook and the repo and are still waiting for your first project to start, go and talk to the person in charge of onboarding.
 They will find something meaningful for you to do which might be something like:
 
-- (Optional) Browse the project board and emoji any projects in the `Looking for people` and `Awaiting start` columns
-  - Note: you will be notified to do this before being assigned to a project
+- Browse the [Project tracker](https://github.com/alan-turing-institute/Hut23/projects/2) and emoji any projects in the `Finding people` and `Awaiting go/no-go` columns.
+  - Note: you will be notified to do this before being assigned to a project.
+- Browse the [Service areas list](https://github.com/alan-turing-institute/research-engineering-group/wiki/Service-areas), discuss the different areas with people involved and emoji those that are looking for people.
 - Work on a Turing Data Story. There's always a story to join or a new one to start. You can then keep working on it on your 22 days time once allocated to a project. This option has been very popular.
 - Tackle a GitHub issue marked with the `good first issue` tag in a repo that REG works on. Whenever a new starter is looking for things to do, the person in charge of onboarding will send a message on Slack asking everyone to tag suitable issues.
 - Work on a REG-internal project that is easy to rotate in/out of.


### PR DESCRIPTION
## Summary

On the "First few days" page the advice to emoji the "Awaiting Start" column in the Project tracker didn't match that on the Checklist or Project Tracking pages, where the advice is to emoji the "Awaiting go/no-go" column. This change aligns the three to all refer to the "Awaiting go/no-go" column.

Advice to look at the Service areas list has also been added.

## Related issues

N/A

## Screenshots

N/A
---

### Updates
