### PR TITLE
Add joining the RSE to the new joiner checklist

### DIFF
--- a/content/docs/onboarding/new_joiners/checklist.md
+++ b/content/docs/onboarding/new_joiners/checklist.md
@@ -81,3 +81,4 @@ If anything is unclear, please figure it out by e.g. asking your buddies, and th
 ## Ongoing activity sign-up
 
 - [ ] "Tech Talks" (Tuesdays 12:30pm), link on: https://github.com/alan-turing-institute/DataScienceSkills/wiki/Lunchtime-Tech-Talks
+- [ ] Read up about and optionally join the [Society of Research Software Engineering](https://society-rse.org/), including the [Slack workspace](https://ukrse.slack.com/join/signup)

--- a/content/docs/onboarding/new_joiners/checklist.md
+++ b/content/docs/onboarding/new_joiners/checklist.md
@@ -81,4 +81,4 @@ If anything is unclear, please figure it out by e.g. asking your buddies, and th
 ## Ongoing activity sign-up
 
 - [ ] "Tech Talks" (Tuesdays 12:30pm), link on: https://github.com/alan-turing-institute/DataScienceSkills/wiki/Lunchtime-Tech-Talks
-- [ ] Read up about and optionally join the [Society of Research Software Engineering](https://society-rse.org/), including the [Slack workspace](https://ukrse.slack.com/join/signup)
+- [ ] Read up about and you are recommended to join the [Society of Research Software Engineering](https://society-rse.org/), including the [Slack workspace](https://ukrse.slack.com/join/signup)

--- a/content/docs/onboarding/new_joiners/systems_set_up.md
+++ b/content/docs/onboarding/new_joiners/systems_set_up.md
@@ -130,7 +130,7 @@ Tips for using Geekbot:
 
 Other workspaces you could join:
 
-- The [Society of Research Software Engineering](https://society-rse.org/) has a website, Slack and email list. Their [Slack workspace](https://ukrse.slack.com/join/signup) contains plenty of details about relevant events.
+- The Society of Research Software Engineering has a [Slack worspace](https://ukrse.slack.com/join/signup). For information about joining the Society see the [SocRSE page]({{< relref "../society_of_research_software_engineering.md" >}}).
 
 ### Mailing Lists
 

--- a/content/docs/onboarding/society_of_research_software_engineering.md
+++ b/content/docs/onboarding/society_of_research_software_engineering.md
@@ -1,0 +1,44 @@
+---
+# Page title as it appears in the navigation menu
+title: "SocRSE"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 1
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Society of Research Software Engineering
+
+The [Society of Research Software Engineering](https://society-rse.org/) (SocRSE) is a charitable incorporated organisation
+with the mission to establish a research environment that recognises the vital role of software in research.
+
+REG supports and encourages its members to join the SocRSE, so it's worth reviewing the society's website and deciding whether to join during your onboarding period.
+
+## Benefits of SocRSE
+
+There are many benefits to joining the SocRSE. By joining the Society you will:
+
+- Contribute to [the Society's work](https://society-rse.org/community/) supporting the research software engineering community
+- Gain access to the Society's [Events & Initiatives fund](https://society-rse.org/policy-for-socrse-events-and-initiatives-grant/)
+- Get discounted access to the Society's annual conference
+- Be eligible to vote and stand for election at the Society's annual AGM
+- Have your say in one of the Society's [special interest, regional or working groups](https://society-rse.org/community/get-involved/)
+- Be able to apply for the Society’s [mentorship scheme](https://society-rse.org/society-of-rse-mentoring-scheme-sign-up/)
+- Gain access to discounts from the Society's corporate sponsors
+
+## Communication Channels
+
+The Society has a website, Slack and email list.
+Their [Slack workspace](https://ukrse.slack.com/join/signup) contains plenty of details about relevant events.
+
+## Claiming Back Subscriptions
+
+SocRSE membership is considered a professional subscription,
+which you're entitled to claim back as a REG member.
+
+You should claim it back quickly after payment.
+Use Certify to claim it back and don't select a project when making your claim.


### PR DESCRIPTION
## Summary
Joining the Society of Research Software Engineering is mentioned on the "Systems Set Up" page for new joiners, but isn't currently featured in the new joiner Checklist. This change adds it in.

## Related issues
N/A

## Screenshots
N/A

---

### Updates
N/A
