### PR TITLE
Reorganise documentation - Round 1

### DIFF
--- a/content/docs/miscellaneous/_index.md
+++ b/content/docs/miscellaneous/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Miscellaneous"
+weight: 7
+---
+
+# Miscellaneous

--- a/content/docs/miscellaneous/acronyms_and_abbreviations.md
+++ b/content/docs/miscellaneous/acronyms_and_abbreviations.md
@@ -13,33 +13,33 @@ weight: 1
 
 # Acronyms and Abbreviations
 
-AIDA: Artificial Intelligence for Data Analytics  
-ALOGIT: name of a Fortran package (see [issue](https://github.com/alan-turing-institute/Hut23/issues/295))  
+AIDA: Artificial Intelligence for Data Analytics
+ALOGIT: name of a Fortran package (see [issue](https://github.com/alan-turing-institute/Hut23/issues/295))
 ASG: AI for Science and Government (the new name of the EPSRC funds from SPF)
 
 ARC: Australian Research Council
 
-BL: British Library  
-BPT: Bayesian Performance Tuning  
+BL: British Library
+BPT: Bayesian Performance Tuning
 
-Chrono: Chronotopic Cartographies  
-CPD: Change-point detection (method to apply to data in AIDA-Lloyds project)   
-CT: Computerised Tomography  
+Chrono: Chronotopic Cartographies
+CPD: Change-point detection (method to apply to data in AIDA-Lloyds project)
+CT: Computerised Tomography
 
-DAS: Data Availability Statements (Giovanni's 22-days research paper)   
-DAFNI: [Data & Analytics Facility for National Infrastructure](https://www.dafni.ac.uk/)  
+DAS: Data Availability Statements (Giovanni's 22-days research paper)
+DAFNI: [Data & Analytics Facility for National Infrastructure](https://www.dafni.ac.uk/)
 DC: Detector-Checker
 
-D&S: Defence and Security (Programme)  
-DS&DH: Data Science & Digital Humanities (Special Interest Group)  
-DSB: Data Science Benchmarking  
-DS for SD: Data Science for Sustainable Development  
-DSG: Data Study Group  
-DSSG: Data Science for Social Good  
-DSSH: Data Science for Science and the Humanities (Programme)  
+D&S: Defence and Security (Programme)
+DS&DH: Data Science & Digital Humanities (Special Interest Group)
+DSB: Data Science Benchmarking
+DS for SD: Data Science for Sustainable Development
+DSG: Data Study Group
+DSSG: Data Science for Social Good
+DSSH: Data Science for Science and the Humanities (Programme)
 
-EDS: Economic Data Science  
-EOM: End of message  
+EDS: Economic Data Science
+EOM: End of message
 
 GUARD: Global Urban Analytics for Resilient Defence
 
@@ -62,24 +62,24 @@ PDQ:  Proof-Driven Query
 PFEA: Probabilistic Finite Element Analysis
 
 RCP: Research Computing Platforms
-RCWG: Research Computing Working Group  
-RDA: Research Data Alliance  
-RDS: Research Data Scientist   
-REG: Research Engineering Group  
-RepRes: Reproducible Research  
-RSD: Research Software Development  
-RSE: Research Software Engineer(ing)  
+RCWG: Research Computing Working Group
+RDA: Research Data Alliance
+RDS: Research Data Scientist
+REG: Research Engineering Group
+RepRes: Reproducible Research
+RSD: Research Software Development
+RSE: Research Software Engineer(ing)
 
-SHEEP: SHEEP is a Homomorphic Encryption Evaluation Platform  
+SHEEP: SHEEP is a Homomorphic Encryption Evaluation Platform
 SPF: [Strategic Priorities Fund](https://www.turing.ac.uk/research/research-programmes/artificial-intelligence-ai/programme-articles/alan-turing-institute-spearhead-new-cutting-edge-data-science-and-ai-research-after-ps48-million) (see also ASG)
 
-TDA: Topological Data Analysis  
-TPS: Tools, Practices, and Systems  
-TMF: Toyota Mobility Foundation  
-TNA: The National Archives  
+TDA: Topological Data Analysis
+TPS: Tools, Practices, and Systems
+TMF: Toyota Mobility Foundation
+TNA: The National Archives
 TTW: The Turing Way
 
-UQBB: Uncertainty Quantification for Black Box Computational Models  
+UQBB: Uncertainty Quantification for Black Box Computational Models
 UQM^3: Uncertainty Quantification in Multi-scale, Multi-physics Models
 
-WFH: Working from home  
+WFH: Working from home

--- a/content/docs/miscellaneous/acronyms_and_abbreviations.md
+++ b/content/docs/miscellaneous/acronyms_and_abbreviations.md
@@ -1,0 +1,85 @@
+---
+# Page title as it appears in the navigation menu
+title: "Acronyms and Abbreviations"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 1
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Acronyms and Abbreviations
+
+AIDA: Artificial Intelligence for Data Analytics  
+ALOGIT: name of a Fortran package (see [issue](https://github.com/alan-turing-institute/Hut23/issues/295))  
+ASG: AI for Science and Government (the new name of the EPSRC funds from SPF)
+
+ARC: Australian Research Council
+
+BL: British Library  
+BPT: Bayesian Performance Tuning  
+
+Chrono: Chronotopic Cartographies  
+CPD: Change-point detection (method to apply to data in AIDA-Lloyds project)   
+CT: Computerised Tomography  
+
+DAS: Data Availability Statements (Giovanni's 22-days research paper)   
+DAFNI: [Data & Analytics Facility for National Infrastructure](https://www.dafni.ac.uk/)  
+DC: Detector-Checker
+
+D&S: Defence and Security (Programme)  
+DS&DH: Data Science & Digital Humanities (Special Interest Group)  
+DSB: Data Science Benchmarking  
+DS for SD: Data Science for Sustainable Development  
+DSG: Data Study Group  
+DSSG: Data Science for Social Good  
+DSSH: Data Science for Science and the Humanities (Programme)  
+
+EDS: Economic Data Science  
+EOM: End of message  
+
+GUARD: Global Urban Analytics for Resilient Defence
+
+HPC: High Performance Computing
+
+IAG: International Airlines Group (British Airways merged with Iberia to form IAG)
+
+KF: Knowledge Flows
+
+LwM: Living with Machines
+
+MRO: ?
+
+NATS: National Air Traffic Services
+
+OpenMP: [Open Multi-Processing](https://en.wikipedia.org/wiki/OpenMP)
+
+PDQ:  Proof-Driven Query
+
+PFEA: Probabilistic Finite Element Analysis
+
+RCP: Research Computing Platforms
+RCWG: Research Computing Working Group  
+RDA: Research Data Alliance  
+RDS: Research Data Scientist   
+REG: Research Engineering Group  
+RepRes: Reproducible Research  
+RSD: Research Software Development  
+RSE: Research Software Engineer(ing)  
+
+SHEEP: SHEEP is a Homomorphic Encryption Evaluation Platform  
+SPF: [Strategic Priorities Fund](https://www.turing.ac.uk/research/research-programmes/artificial-intelligence-ai/programme-articles/alan-turing-institute-spearhead-new-cutting-edge-data-science-and-ai-research-after-ps48-million) (see also ASG)
+
+TDA: Topological Data Analysis  
+TPS: Tools, Practices, and Systems  
+TMF: Toyota Mobility Foundation  
+TNA: The National Archives  
+TTW: The Turing Way
+
+UQBB: Uncertainty Quantification for Black Box Computational Models  
+UQM^3: Uncertainty Quantification in Multi-scale, Multi-physics Models
+
+WFH: Working from home  

--- a/content/docs/miscellaneous/books_and_journal_access.md
+++ b/content/docs/miscellaneous/books_and_journal_access.md
@@ -23,12 +23,11 @@ If you register as a researcher / academic then you get a longer lasting reader 
 
 **Note: this section needs reviewing, might be outdated.**
 
-To use the online interface you will first need to create an online account. To do this you have to complete the form found here: <https://register.bl.uk/RegOnline.aspx?serviceId=3>.
+To use the online interface you will first need to create an online account. To do this you have to complete the form found here (**Note**: original link is dead, need to replace it).
 
 - Simply click on the Register button and complete your details.
 - After registration you will be sent an e-mail to validate the account including a unique ID number.
-- You need to click on the link in the e-mail, log in using the username and password you have just created and answer the questions.
-Once you have completed this process you can let HR have your online account ID number and they can then add you to the central Turing account.
+- You need to click on the link in the e-mail, log in using the username and password you have just created and answer the questions. Once you have completed this process you can let HR have your online account ID number and they can then add you to the central Turing account.
 
 The account has been set up as follows:
 

--- a/content/docs/miscellaneous/books_and_journal_access.md
+++ b/content/docs/miscellaneous/books_and_journal_access.md
@@ -21,6 +21,8 @@ If you register as a researcher / academic then you get a longer lasting reader 
 
 ## How to be added onto the BL journal access
 
+**Note: this section needs reviewing, might be outdated.**
+
 To use the online interface you will first need to create an online account. To do this you have to complete the form found here: <https://register.bl.uk/RegOnline.aspx?serviceId=3>.
 - Simply click on the Register button and complete your details.
 - After registration you will be sent an e-mail to validate the account including a unique ID number.

--- a/content/docs/miscellaneous/books_and_journal_access.md
+++ b/content/docs/miscellaneous/books_and_journal_access.md
@@ -24,20 +24,22 @@ If you register as a researcher / academic then you get a longer lasting reader 
 **Note: this section needs reviewing, might be outdated.**
 
 To use the online interface you will first need to create an online account. To do this you have to complete the form found here: <https://register.bl.uk/RegOnline.aspx?serviceId=3>.
+
 - Simply click on the Register button and complete your details.
 - After registration you will be sent an e-mail to validate the account including a unique ID number.
 - You need to click on the link in the e-mail, log in using the username and password you have just created and answer the questions.
 Once you have completed this process you can let HR have your online account ID number and they can then add you to the central Turing account.
 
 The account has been set up as follows:
-* 24 hours as standard service.
-* The delivery method is DRM Lite. Information and FAQ’s can be found here: <https://www.bl.uk/help/how-to-open-your-on-demand-order>.
-* Currently you will receive one reply email per day.
-* The account allows requests to be made on the Library Privilege service for those request that are being used for research or educational purposes.
-* For any orders that will be used for commercial purposes you have the option to request a copyright fee.
-* It is a paid service but we will pick up the cost centrally, at least during the trial.
-* Each subscription is unique so please do not share your log in details.
-* Each request asks for a reference and we would suggest you use your initials followed by a sequential number.
+
+- 24 hours as standard service.
+- The delivery method is DRM Lite. Information and FAQ’s can be found here: <https://www.bl.uk/help/how-to-open-your-on-demand-order>.
+- Currently you will receive one reply email per day.
+- The account allows requests to be made on the Library Privilege service for those request that are being used for research or educational purposes.
+- For any orders that will be used for commercial purposes you have the option to request a copyright fee.
+- It is a paid service but we will pick up the cost centrally, at least during the trial.
+- Each subscription is unique so please do not share your log in details.
+- Each request asks for a reference and we would suggest you use your initials followed by a sequential number.
 
 Any problem give HR a shout.
 

--- a/content/docs/miscellaneous/books_and_journal_access.md
+++ b/content/docs/miscellaneous/books_and_journal_access.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Books and Journal Access"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 1
+weight: 2
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/miscellaneous/books_and_journal_access.md
+++ b/content/docs/miscellaneous/books_and_journal_access.md
@@ -1,0 +1,44 @@
+---
+# Page title as it appears in the navigation menu
+title: "Books and Journal Access"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 1
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Books and Journal Access
+
+## Get books from the library
+
+You need to get a membership card, then books can be requested. Note that the library does not do loans.
+
+If you register as a researcher / academic then you get a longer lasting reader pass. You need proof of identity with signature and proof of address to get a reader pass. See [here](https://www.bl.uk/help/how-to-get-a-reader-pass).
+
+## How to be added onto the BL journal access
+
+To use the online interface you will first need to create an online account. To do this you have to complete the form found here: <https://register.bl.uk/RegOnline.aspx?serviceId=3>.
+- Simply click on the Register button and complete your details.
+- After registration you will be sent an e-mail to validate the account including a unique ID number.
+- You need to click on the link in the e-mail, log in using the username and password you have just created and answer the questions.
+Once you have completed this process you can let HR have your online account ID number and they can then add you to the central Turing account.
+
+The account has been set up as follows:
+* 24 hours as standard service.
+* The delivery method is DRM Lite. Information and FAQ’s can be found here: <https://www.bl.uk/help/how-to-open-your-on-demand-order>.
+* Currently you will receive one reply email per day.
+* The account allows requests to be made on the Library Privilege service for those request that are being used for research or educational purposes.
+* For any orders that will be used for commercial purposes you have the option to request a copyright fee.
+* It is a paid service but we will pick up the cost centrally, at least during the trial.
+* Each subscription is unique so please do not share your log in details.
+* Each request asks for a reference and we would suggest you use your initials followed by a sequential number.
+
+Any problem give HR a shout.
+
+## Buy literature (books, etc.)
+
+Ask on a case by case to your line manager. Given approval, you can order directly and get a refund.

--- a/content/docs/technical_practices/azure/_index.md
+++ b/content/docs/technical_practices/azure/_index.md
@@ -12,6 +12,7 @@ weight: 6
 ---
 
 # Azure
+
 Azure is Microsoft's cloud service. The Turing has a grant from Microsoft to use this.
 
 ## Setting up Azure
@@ -26,6 +27,7 @@ To experiment with Azure you should request a trial account with $300 credit usi
 - [Azure Howtos](https://github.com/alan-turing-institute/howtos/tree/master/azure)
 
 ## Managing your Azure account
+
 - [Using Microsoft Azure at the Turing](https://mathison.turing.ac.uk/page/2433)
 - [Monitor available credit on an Azure subscription](https://rcp-api-prod.azurewebsites.net/)
 - Email the [Research Compute Platforms team](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact) for help

--- a/content/docs/technical_practices/azure/_index.md
+++ b/content/docs/technical_practices/azure/_index.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Azure"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 1
+weight: 6
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu
@@ -12,3 +12,22 @@ weight: 1
 ---
 
 # Azure
+Azure is Microsoft's cloud service. The Turing has a grant from Microsoft to use this. 
+
+## Setting up Azure
+
+You can access Azure through the [Azure portal](https://portal.azure.com), using your Office 365 credentials.
+
+To experiment with Azure you should request a trial account with $300 credit using this [TopDesk Link](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=ac51b39d8bfc46f9bf41132ef8601b5e&from=7edfe644-ac0d-4895-af98-acd425ee0b19&openedFromService=true). When using Azure for projects you can use the same form to request a project-specific subscription with its own budget.
+
+## Quick links
+
+- [Azure Quickstart: Make a new VM using the command line]({{< relref "docs/technical_practices/azure/azure_make_vm_with_cli.md" >}})
+- [Azure Howtos](https://github.com/alan-turing-institute/howtos/tree/master/azure)
+
+## Managing your Azure account
+- [Azure on TopDesk](https://turingcomplete.topdesk.net/tas/public/ssp/content/detail/service?unid=01cdabaf94d74351a626ab94933751a9)
+- [Request a new subscription](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=5c60fe7e31094c019fad0f49fab638d7) - use this for an initial personal or project allocation.
+- [Request additional credit](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=859fad77c07743f4a978a7f48f73db83) - use this to ask for more credit for a personal or project subscription
+- [Monitor available credit on an Azure subscription](https://turingazureusage.azurewebsites.net/)
+- Email the [Research Compute Platforms team](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact) for help

--- a/content/docs/technical_practices/azure/_index.md
+++ b/content/docs/technical_practices/azure/_index.md
@@ -12,7 +12,7 @@ weight: 6
 ---
 
 # Azure
-Azure is Microsoft's cloud service. The Turing has a grant from Microsoft to use this. 
+Azure is Microsoft's cloud service. The Turing has a grant from Microsoft to use this.
 
 ## Setting up Azure
 

--- a/content/docs/technical_practices/azure/_index.md
+++ b/content/docs/technical_practices/azure/_index.md
@@ -1,0 +1,14 @@
+---
+# Page title as it appears in the navigation menu
+title: "Azure"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 1
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Azure

--- a/content/docs/technical_practices/azure/_index.md
+++ b/content/docs/technical_practices/azure/_index.md
@@ -26,8 +26,6 @@ To experiment with Azure you should request a trial account with $300 credit usi
 - [Azure Howtos](https://github.com/alan-turing-institute/howtos/tree/master/azure)
 
 ## Managing your Azure account
-- [Azure on TopDesk](https://turingcomplete.topdesk.net/tas/public/ssp/content/detail/service?unid=01cdabaf94d74351a626ab94933751a9)
-- [Request a new subscription](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=5c60fe7e31094c019fad0f49fab638d7) - use this for an initial personal or project allocation.
-- [Request additional credit](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=859fad77c07743f4a978a7f48f73db83) - use this to ask for more credit for a personal or project subscription
-- [Monitor available credit on an Azure subscription](https://turingazureusage.azurewebsites.net/)
+- [Using Microsoft Azure at the Turing](https://mathison.turing.ac.uk/page/2433)
+- [Monitor available credit on an Azure subscription](https://rcp-api-prod.azurewebsites.net/)
 - Email the [Research Compute Platforms team](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact) for help

--- a/content/docs/technical_practices/azure/azure_make_vm_with_cli.md
+++ b/content/docs/technical_practices/azure/azure_make_vm_with_cli.md
@@ -26,16 +26,13 @@ Set up a basic Azure VM running Ubuntu using the command line tools.
 ## Steps
 
 1. `az login`, then find your subscription.
-
-2. Maybe you need `az account list --output table` to find your subscriptions,
+1. Maybe you need `az account list --output table` to find your subscriptions,
    and `az account set -s <subscription-id>` to set the correct one as the
    default.
-
-3. `az group create --name <group-name> --location uksouth` to make a “resource
+1. `az group create --name <group-name> --location uksouth` to make a “resource
    group” which holds all the various bits and pieces of this server. To get a
    list of locations do `az account list-locations`.
-
-4. Make a VM, attach some storage units. The "Standard_B2s" size is a 2 core, 4
+1. Make a VM, attach some storage units. The "Standard_B2s" size is a 2 core, 4
    GB ram machine, with 30GB of local storage, which is suitable for "bursty"
    tasks. (Basically, when you let it run at less than 100% for a while, you
    build up 'credits' that let you run it at more than 100% for a time. Or
@@ -43,18 +40,18 @@ Set up a basic Azure VM running Ubuntu using the command line tools.
 
    I've added a 128 GB disk. The "Standard_LRS" disk is an HDD, not an SSD.
 
-```
-az vm create \
-    --name <name-of-machine-maybe> \
-    --resource-group <group-name> \
-    --image UbuntuLTS \
-    --size Standard_B2s \
-    --data-disk-sizes-gb 128 \
-    --storage-sku Standard_LRS \
-    --ssh-key-values ~/.ssh/id_rsa.pub
-```
+    ```bash
+    az vm create \
+        --name <name-of-machine-maybe> \
+        --resource-group <group-name> \
+        --image UbuntuLTS \
+        --size Standard_B2s \
+        --data-disk-sizes-gb 128 \
+        --storage-sku Standard_LRS \
+        --ssh-key-values ~/.ssh/id_rsa.pub
+    ```
 
-5. Now you have to format and mount the data disk.
+1. Now you have to format and mount the data disk.
 
    - `lsblk` This finds the disk (you can tell which one is the data disk by its
      size). Mine was `sbc`

--- a/content/docs/technical_practices/azure/azure_make_vm_with_cli.md
+++ b/content/docs/technical_practices/azure/azure_make_vm_with_cli.md
@@ -1,0 +1,79 @@
+---
+# Page title as it appears in the navigation menu
+title: "Quickstart: Make a new VM using the command line"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 1
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Azure via CLI basic quickstart
+
+## Goal
+
+Set up a basic Azure VM running Ubuntu using the command line tools.
+
+## Assumptions
+
+- You have the command line tools installed already.
+- You can recognise your subscription ID.
+- You know which region you want and which VM you want.
+
+## Steps
+
+1. `az login`, then find your subscription.
+
+2. Maybe you need `az account list --output table` to find your subscriptions,
+   and `az account set -s <subscription-id>` to set the correct one as the
+   default.
+   
+3. `az group create --name <group-name> --location uksouth` to make a “resource
+   group” which holds all the various bits and pieces of this server. To get a
+   list of locations do `az account list-locations`.
+   
+4. Make a VM, attach some storage units. The "Standard_B2s" size is a 2 core, 4
+   GB ram machine, with 30GB of local storage, which is suitable for "bursty"
+   tasks. (Basically, when you let it run at less than 100% for a while, you
+   build up 'credits' that let you run it at more than 100% for a time. Or
+   something like that.) 
+   
+   I've added a 128 GB disk. The "Standard_LRS" disk is an HDD, not an SSD.
+
+```
+az vm create \
+    --name <name-of-machine-maybe> \
+    --resource-group <group-name> \
+    --image UbuntuLTS \
+    --size Standard_B2s \
+    --data-disk-sizes-gb 128 \
+    --storage-sku Standard_LRS \
+    --ssh-key-values ~/.ssh/id_rsa.pub
+```
+
+5. Now you have to format and mount the data disk. 
+
+   - `lsblk` This finds the disk (you can tell which one is the data disk by its
+     size). Mine was `sbc`
+     
+   - Partition and format the disk (replace `sdc` with your disk).
+     - `sudo parted /dev/sdc --script mklabel gpt mkpart btrfspart btrfs 0% 100%`
+     - `sudo mkfs.btrfs /dev/sdc1`
+     - `sudo partprobe /dev/sdc1`
+     
+     (Actually, the instructions suggested "xfs" everywhere instead of
+     "btrfs". But what the hey.)
+     
+   - Mount the disk
+     - `sudo mkdir /data`
+     - `sudo mount /dev/sdc1 /data`
+     
+   - Make the mount point persist across reboots.
+     - `sudo blkid` -- find the UUID of this disk
+     - Edit `/etc/fstab` (eg, via `sudo nano /etc/fstab`) to add the line:
+       `UUID=<uuid found above>   /data   btrfs   defaults,nofail   1   2`
+      
+ 

--- a/content/docs/technical_practices/azure/azure_make_vm_with_cli.md
+++ b/content/docs/technical_practices/azure/azure_make_vm_with_cli.md
@@ -30,17 +30,17 @@ Set up a basic Azure VM running Ubuntu using the command line tools.
 2. Maybe you need `az account list --output table` to find your subscriptions,
    and `az account set -s <subscription-id>` to set the correct one as the
    default.
-   
+
 3. `az group create --name <group-name> --location uksouth` to make a “resource
    group” which holds all the various bits and pieces of this server. To get a
    list of locations do `az account list-locations`.
-   
+
 4. Make a VM, attach some storage units. The "Standard_B2s" size is a 2 core, 4
    GB ram machine, with 30GB of local storage, which is suitable for "bursty"
    tasks. (Basically, when you let it run at less than 100% for a while, you
    build up 'credits' that let you run it at more than 100% for a time. Or
-   something like that.) 
-   
+   something like that.)
+
    I've added a 128 GB disk. The "Standard_LRS" disk is an HDD, not an SSD.
 
 ```
@@ -54,26 +54,24 @@ az vm create \
     --ssh-key-values ~/.ssh/id_rsa.pub
 ```
 
-5. Now you have to format and mount the data disk. 
+5. Now you have to format and mount the data disk.
 
    - `lsblk` This finds the disk (you can tell which one is the data disk by its
      size). Mine was `sbc`
-     
+
    - Partition and format the disk (replace `sdc` with your disk).
      - `sudo parted /dev/sdc --script mklabel gpt mkpart btrfspart btrfs 0% 100%`
      - `sudo mkfs.btrfs /dev/sdc1`
      - `sudo partprobe /dev/sdc1`
-     
+
      (Actually, the instructions suggested "xfs" everywhere instead of
      "btrfs". But what the hey.)
-     
+
    - Mount the disk
      - `sudo mkdir /data`
      - `sudo mount /dev/sdc1 /data`
-     
+
    - Make the mount point persist across reboots.
      - `sudo blkid` -- find the UUID of this disk
      - Edit `/etc/fstab` (eg, via `sudo nano /etc/fstab`) to add the line:
        `UUID=<uuid found above>   /data   btrfs   defaults,nofail   1   2`
-      
- 

--- a/content/docs/technical_practices/how_to_use_hub23.md
+++ b/content/docs/technical_practices/how_to_use_hub23.md
@@ -15,6 +15,8 @@ weight: 7
 
 **Note**: this likely needs updating, last revision was in Nov 2019.
 
+**Note**: Hub23 is not being looked after and it is not currently active.
+
 ## What is a BinderHub?
 
 A [BinderHub](https://binderhub.readthedocs.io/en/latest/index.html) is a Cloud-based technology that can launch a repository of code (from GitHub, GitLab,...) in a browser window such that the code can be executed and interacted with.

--- a/content/docs/technical_practices/how_to_use_hub23.md
+++ b/content/docs/technical_practices/how_to_use_hub23.md
@@ -1,0 +1,131 @@
+---
+# Page title as it appears in the navigation menu
+title: "How to Use Hub23"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 7
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# How to use Hub23: the Turing BinderHub
+
+**Note**: this likely needs updating, last revision was in Nov 2019.
+
+## What is a BinderHub?
+
+A [BinderHub](https://binderhub.readthedocs.io/en/latest/index.html) is a Cloud-based technology that can launch a repository of code (from GitHub, GitLab,...) in a browser window such that the code can be executed and interacted with.
+A unique URL is generated allowing the interactive code to be easily shared.
+
+The purpose of these Binder instances is to promote reproducibility in research projects by encouraging researchers to document their software dependencies by producing fun and interactive environments!
+
+## Why build a BinderHub at the Turing?
+
+[mybinder.org](https://mybinder.org/) is a free, public service that hosts almost 100k Binder launches per week.
+Why do we need to have our own?
+
+Binder is an open source project maintained by volunteers and as such they ask that users stay within certain limitations in order to keep running costs as low as possible whilst still providing a usable service.
+By hosting our own BinderHub, we can offer much more flexible and tailored resources to our users.
+These include:
+
+- authentication,
+- greater computational resources per user,
+- bespoke library stacks,
+- hosting private repos,
+- persistent storage for users.
+
+We have also contributed to the Binder community by sharing our knowledge on building BinderHubs on Azure!
+(mybinder.org runs on Google Cloud.)
+
+## How does BinderHub work?
+
+- [`repo2docker`](https://repo2docker.readthedocs.io/en/latest/?badge=latest)
+
+  `repo2docker` is a tool that will build a Docker image from a code repository given a configuration file.
+
+- [Kubernetes](https://kubernetes.io/)
+
+  Kubernetes is a system for automating deployment, scaling, and management of containerised applications across a compute cluster (Cloud-based, bare-metal or otherwise).
+
+- [JupyterHub](https://jupyter.org/hub)
+
+  JupyterHub is a multi-user server for Jupyter Notebooks and containers alike.
+
+Kubernetes provides the compute resources from the Cloud-based cluster to run a container built by `repo2docker`.
+The JupyterHub provides the browser-based environment for the container to run in and connects your browser to it.
+
+## How to gain access to Hub23
+
+1. You need to be a member of the `binderhub-test-org` on GitHub.
+   Ask Sarah Gibson to send you an invitation over Slack or via email (don't forget to include your GitHub username in your message!).
+   Check your email for the invitation.
+1. Your membership of `binderhub-test-org` must be **public**, but will be private by default when you join.
+   To change it, go to <https://github.com/orgs/binderhub-test-org/people> and find your username.
+   Click the arrow next to where it says "Private" and select "Public" from the drop-down menu.
+1. Go to [binder.hub23.turing.ac.uk](http://binder.hub23.turing.ac.uk) and login with your GitHub username and password!
+   You will be asked to authorise an OAuth app from `binderhub-test-org`.
+   This has read-only permissions to read your organisation/team memberships and is why your membership needs to be public!
+
+## How to use the Hub23 Binder
+
+1. Copy the URL of a Binder-ready repo into the URL box on the Hub23 Binder homepage.
+   There is a drop-down menu to say whether the repo is from GitHub, GitLab, etc.
+   - You can specify a specific branch, tag or commit to build in the "Git branch, tag or commit" box.
+   - You can specify a file to be opened on launch by filling in the "Path to notebook file" box with a path relative the the repo root.
+   - You can specify an environment to be launched by changing the drop-down menu next to the "Path to notebook file" box to URL.
+     Enter `lab` for a JupyterLab environment, or `rstudio` for RStudio.
+1. Press launch!
+   The repo will be spun up on a server in the Cloud and connected to your browser.
+
+### How do you know if a repo is Binder-ready?
+
+A Binder-ready repo should contain a configuration file in its root that lists all the software needed to run the code.
+
+For Python, this may be a `requirements.txt` or `environment.yml` file.
+For R, this may be `NAME` and `DESCRIPTION` files or an `install.R` file.
+
+It must also contain a `runtime.txt` file which contains the version of the core programming language.
+For example:
+
+```bash
+python-3.6          # To pin to v3.6 of python
+r-<YYYY>-<MM>-<DD>  # To pin to a specific version of R published on MRAN
+```
+
+Just because these files exist, doesn't necessarily mean that Binder will be able to launch them first time!
+Some debugging may be required!
+
+## How to make your own repo Binder ready
+
+To make your repo Binder-ready, you need to provide a configuration file which describes your software into the root of the repo.
+
+The Binder team have provided a list of minimum working examples for a variety of configuration files [here](https://mybinder.readthedocs.io/en/latest/config_files.html#configuration-files).
+The [binder-examples](https://github.com/binder-examples) organisation is also a good place to find examples of different configurations.
+
+A very high-level, Python-based tutorial is available [here](https://bit.ly/zero-to-binder-solo) or you can read the Binder section of _The Turing Way_ book [here](https://the-turing-way.netlify.com/reproducible_environments/reproducible_environments.html#binder-1).
+
+To auto-generate config files for a Python environment:
+
+```bash
+pip freeze > requirements.txt
+conda env export > environment.yml
+```
+
+## Troubleshooting
+
+If you have any problems, check out the [mybinder documentation](https://mybinder.readthedocs.io/en/latest/), [open an issue](https://github.com/alan-turing-institute/hub23-deploy/issues/new) on the deployment repo, or ask Sarah Gibson.
+
+## Some caveats to remember when using Binder
+
+🚧 🚧 Hub23 is under active development and so the below is subject to change. 🚧 🚧
+
+- Only public repos can be built.
+- Don't upload sensitive data, secrets, keys, anything you don't want accessible by the world!
+- Each user is allocated 0.5 vCPU and 1GB RAM and your kernel will be killed if your computation exceeds this.
+- The more code/data in your repo, the bigger your Docker image will be, the longer it will take to build/load.
+  Consider using a [postBuild](https://mybinder.readthedocs.io/en/latest/config_files.html#postbuild-run-code-after-installing-the-environment) file to download data or stream it as part of your code.
+- Any changes you make in a running Binder will be lost when you close the browser window - even if you clicked save!
+- Only connections via HTTP or HTTPS are accepted by a Binder.


### PR DESCRIPTION
<!--
Thank you for contributing!

Please use this pull request template to describe the changes you have made.

- Make sure that you give your pull request a meaningful title.
- If this work is not ready to merge yet, please make it a draft pull request.
- Make sure that your branch is up-to-date with main.
- There is no need to add labels to your pull request.
- You can assign particular reviewers if you want to, but there is no need to.

Note that text in html comments will not be rendered.
-->

## Summary
This is the first round of changes I intend to make while reorganizing content across the three places that REG uses to host its documentation: [the Hut23 wiki](https://github.com/alan-turing-institute/Hut23/wiki), [the REG wiki](https://github.com/alan-turing-institute/research-engineering-group/wiki) and this Handbook.

## Related issues and PRs
- Contributes to #21
- This [pull request](https://github.com/alan-turing-institute/Hut23/pull/1435)

---

### Updates

Specifically, I have moved content from the Hut23 and REG wikis to this Handbook. All the information that has been moved is non-confidential, but this should be reviewed.
I have created a new section in the Handbook that I have called "Miscellaneous". This is probably not the best name, but it does actually contain miscellaneous stuff from the Hut23 and REG wikis. As more content is moved to the Handbook, we could think of a better alternative.

Once this PR is merged, I will open equivalent PRs in the REG and Hut23 wikis to remove the relevant content from there so that information is not duplicated across the three sources. More specifically, the content will be replaced with links pointing to the Handbook.