### PR TITLE
Migrate Equipment from REG wiki to Handbook

### DIFF
--- a/content/docs/onboarding/new_joiners/systems_set_up.md
+++ b/content/docs/onboarding/new_joiners/systems_set_up.md
@@ -245,15 +245,10 @@ When you get access to Certify, it's a good idea to check that you've been set u
 If you applied for a visa to work at the Turing, you are also allowed to claim up to £4000 back.
 More details on this can be found in [Mathison](https://mathison.turing.ac.uk/Interact/Pages/Content/Document.aspx?id=2270) as well as the [REG Wiki](https://github.com/alan-turing-institute/research-engineering-group/wiki/Reclaiming-out-of-pocket-expenses#visa-costs).
 
-### Purchasing home office equipment
-
-There is a budget to purchase peripherals (monitor, mouse, keyboard, _etc._) as well as other equipment such as an office chair and desk.
-For peripherals, fill in [this form on Turing Complete](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=eee3b659bb3e4ab5aaed67f807ebd8c3).
-For an office chair and desk, you can purchase these yourself, and claim up to £200 back (in total) via Certify.
-
 ## Reference
 
 Take a look at the following sections:
 
 - [Regular Events]({{< relref "/docs/regular_events/_index.md" >}})
 - [Common Technical Practices]({{< relref "/docs/technical_practices/_index.md" >}})
+- [Equipment]({{< relref "/docs/working_at_the_turing/equipment.md" >}})

--- a/content/docs/onboarding/new_joiners/systems_set_up.md
+++ b/content/docs/onboarding/new_joiners/systems_set_up.md
@@ -29,6 +29,7 @@ If any of the material is unfamiliar (*e.g.* you haven't seen a GitHub project b
 
 Receive (or be assigned) new computer from IT.
 It will have an admin account for IT, and probably an account for you with a default password.
+Contact your line manager as a matter of urgency if you are not able to get a laptop on your first day at the Turing.
 
 Log in with the password provided by IT.
 

--- a/content/docs/working_at_the_turing/equipment.md
+++ b/content/docs/working_at_the_turing/equipment.md
@@ -17,25 +17,25 @@ weight: 2
 
 This is a list of the steps taken by a REG member when they got a new Turing laptop from IT to replace their old laptop. Please note that you don't have to follow these steps, it is just advice given by someone who went through the process.
 
-- [ ] Sign in to Apple Cloud on new machine. Activate all accounts (Office365, personal email, ...)
+1. Sign in to Apple Cloud on new machine. Activate all accounts (Office365, personal email, ...)
 
-- [ ] `brew cask install emacs`, and anything else you need.
+1. `brew cask install emacs`, and anything else you need.
 
-- [ ] Store config files on Apple Cloud, and symbolic link them to their required place, eg:
-  - `~/.emacs.el`
-  - `~/.bash_profile`
+1. Store config files on Apple Cloud, and symbolic link them to their required place, eg:
+   - `~/.emacs.el`
+   - `~/.bash_profile`
 
-- [ ] Office (including OneDrive): install with the new "self service" app that IT now bundle with laptops (which apparently installs things via homebrew!)
+1. Office (including OneDrive): install with the new "self service" app that IT now bundle with laptops (which apparently installs things via homebrew!)
 
-- [ ] OneDrive setup. You might have a personal shared space on OneDrive, but also multiple shared spaces for projects, set up as "Groups" in Office 365. The standard location that Office chooses for your local OneDrive image is long and full of spaces. Put all shared spaces in ~/OneDrive-Actuals and then symbolic link to ~/OneDrive (for my personal space) and ~/Share/X (for project X).
+1. OneDrive setup. You might have a personal shared space on OneDrive, but also multiple shared spaces for projects, set up as "Groups" in Office 365. The standard location that Office chooses for your local OneDrive image is long and full of spaces. Put all shared spaces in ~/OneDrive-Actuals and then symbolic link to ~/OneDrive (for my personal space) and ~/Share/X (for project X).
 
-- [ ] SSH tokens for GitHub. You can make new ones or think about moving the old ones, but it turned out to be straightforward to make new ones.
+1. SSH tokens for GitHub. You can make new ones or think about moving the old ones, but it turned out to be straightforward to make new ones.
 
-- [ ] Go through every repo with an authoritative remote, make sure you've pushed all local commits, and delete. (I keep all repos in `~/Projects/`, with remotes usually on GitHub.)
+1. Go through every repo with an authoritative remote, make sure you've pushed all local commits, and delete. (I keep all repos in `~/Projects/`, with remotes usually on GitHub.)
 
-- [ ] Double-check other directories within `~/`
+1. Double-check other directories within `~/`
 
-- [ ] Install Emacs additions as I learn that I need them ...
+1. Install Emacs additions as I learn that I need them ...
 
 ## Additional Equipment
 

--- a/content/docs/working_at_the_turing/equipment.md
+++ b/content/docs/working_at_the_turing/equipment.md
@@ -1,0 +1,38 @@
+---
+# Page title as it appears in the navigation menu
+title: "Equipment"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 2
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Equipment
+
+## Getting a New Computer
+
+This is a list of the steps taken by a REG member when they got a new laptop for IT. Please note that you don't have to follow these steps, it is just advice given by someone who went through the process.
+
+- [ ] Sign in to Apple Cloud on new machine. Activate all accounts (Office365, personal email, ...)
+
+- [ ] `brew cask install emacs`, and anything else you need.
+
+- [ ] Store config files on Apple Cloud, and symbolic link them to their required place, eg:
+  - `~/.emacs.el`
+  - `~/.bash_profile`
+
+- [ ] Office (including OneDrive): install with the new "self service" app that IT now bundle with laptops (which apparently installs things via homebrew!)
+
+- [ ] OneDrive setup. You might have a personal shared space on OneDrive, but also multiple shared spaces for projects, set up as "Groups" in Office 365. The standard location that Office chooses for your local OneDrive image is long and full of spaces. Put all shared spaces in ~/OneDrive-Actuals and then symbolic link to ~/OneDrive (for my personal space) and ~/Share/X (for project X).
+
+- [ ] SSH tokens for GitHub. You can make new ones or think about moving the old ones, but it turned out to be straightforward to make new ones.
+
+- [ ] Go through every repo with an authoritative remote, make sure you've pushed all local commits, and delete. (I keep all repos in `~/Projects/`, with remotes usually on GitHub.)
+
+- [ ] Double-check other directories within `~/`
+
+- [ ] Install Emacs additions as I learn that I need them ...

--- a/content/docs/working_at_the_turing/equipment.md
+++ b/content/docs/working_at_the_turing/equipment.md
@@ -15,7 +15,7 @@ weight: 2
 
 ## Getting a New Computer
 
-This is a list of the steps taken by a REG member when they got a new laptop for IT. Please note that you don't have to follow these steps, it is just advice given by someone who went through the process.
+This is a list of the steps taken by a REG member when they got a new Turing laptop from IT to replace their old laptop. Please note that you don't have to follow these steps, it is just advice given by someone who went through the process.
 
 - [ ] Sign in to Apple Cloud on new machine. Activate all accounts (Office365, personal email, ...)
 
@@ -36,3 +36,9 @@ This is a list of the steps taken by a REG member when they got a new laptop for
 - [ ] Double-check other directories within `~/`
 
 - [ ] Install Emacs additions as I learn that I need them ...
+
+## Additional Equipment
+
+There is a budget to purchase peripherals (monitor, mouse, keyboard, _etc._) as well as other equipment such as an office chair and desk. You can purchase the office chair and desk yourself and claim back up to £200 in total via Certify. The official process is to assess your home-working set up via a [workstation self-assessment form](https://mathison.turing.ac.uk/page/2810). However, you can try contacting the [facilities team](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact) directly. For peripherals, it's better to contact [IT](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact). See the [Turing's Homeworking Policy](https://mathison.turing.ac.uk/page/2218) for more information.
+
+If there are health and safety reasons why you would want equipment that differs from the standard Apple keyboard/mouse then contact [HR](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact) directly, there is a separate health and safety budget for such things.


### PR DESCRIPTION
Move the Equipment pages of the REG Wiki to a new page in the Handbook