### PR TITLE
fix broken external links

### DIFF
--- a/content/docs/contributing/creating_a_page.md
+++ b/content/docs/contributing/creating_a_page.md
@@ -28,7 +28,7 @@ directory containing a content file called `_index.md`.
 
 {{% hint warning %}}
 It is important that the index file exists for Hugo to [correctly assign pages
-to sections](https://gohugo.io/content-management/sections/#nested-sections) and
+to sections](https://gohugo.io/content-management/sections/) and
 for the [theme](https://github.com/alex-shpak/hugo-book) to arrange pages in the
 tree-like menu.
 {{% /hint %}}

--- a/content/docs/technical_practices/configuring_editors.md
+++ b/content/docs/technical_practices/configuring_editors.md
@@ -124,7 +124,7 @@ Hovering over a piece of code with a problem in the editor will give you more de
 
 ### Formatting
 
-[VSC Formatting Docs](https://code.visualstudio.com/docs/python/editing#_formatting)
+[VSC Formatting Docs](https://code.visualstudio.com/docs/python/formatting)
 
 VS code can use a few different file formatters (e.g. `black`, `yapf`, `autopep8` — we recommend `black`), which can be configured to run automatically when saving files (see settings above) or with the following shortcuts:
 

--- a/content/docs/technical_practices/python.md
+++ b/content/docs/technical_practices/python.md
@@ -118,7 +118,7 @@ The [`pre-commit` documentation](https://pre-commit.com/) provides much more det
 Some suggested testing tools:
 
 - A test framework [pytest](https://docs.pytest.org/) or the less fashionable [unittest](https://docs.python.org/3/library/unittest.html).
-- Coverage reporting [pytest-cov](https://pypi.org/project/pytest-cov/) (a plugin for `pytest`) or [coverage](https://coverage.readthedocs.io/en/stable/).
+- Coverage reporting [pytest-cov](https://pypi.org/project/pytest-cov/) (a plugin for `pytest`) or [coverage](https://coverage.readthedocs.io/).
 - A tool for testing code examples in your documentation [doctest](https://docs.python.org/3/library/doctest.html).
 
 This list of tools does not include a discussion on developing a _testing strategy_.


### PR DESCRIPTION
Fix broken links that cause the "HTML proofer external links" GitHub Action to fail. Note that the Hut23 Twitter account link will fail regardless as it requires log in.