### PR TITLE
Migrate Remote Working page from REG Wiki to handbook

### DIFF
--- a/content/docs/how_we_work/remote_working.md
+++ b/content/docs/how_we_work/remote_working.md
@@ -1,0 +1,96 @@
+---
+# Page title as it appears in the navigation menu
+title: "Remote Working"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 8	
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Remote Working
+
+Information and tips and tricks on working from home and other remote working.
+
+## Meetings, calls and screen sharing
+
+## Gather
+
+REG uses Gather for some of the coffee breaks and social events.
+It gives a virtual space (modelled on the office!) to wander around and have conversations with people near to you.
+
+- See [The REGistry](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#video-call-links) for how to gain entry to gather.
+
+Note: Gather is blocked on the Turing VPN and on IT-managed computers.
+
+### Zoom
+
+Unless requested from IT, you will have a "Basic" Zoom account.
+This allows you to create meetings for up to 40 minutes (unlimited for meetings with only 2 people).
+For meetings longer than this, an upgrade to a "Pro" account is needed. To request a pro account contact [IT Services](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact).
+
+We have a persistent REG Zoom meeting room, which we use for things like coffee breaks, tech talks and co-working.
+See [The REGistry](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#video-call-links) for the location.
+
+For larger events or meetings, Zoom also has some features for Webinars and breakout rooms.
+
+Zoom Rooms (like those associated with each meeting room in the office) are persistent virtual meeting spaces.
+Additional rooms might be able to be requested from IT if required (these seem to be priced at £32/month, so some justification should be given).
+
+For more information on how to get or use Zoom, see the [Zoom TopDesk page](https://turingcomplete.topdesk.net/tas/public/ssp/content/detail/knowledgeitem?unid=e63d1edd1cdc4e8ab3ac3c4e75bb768f).
+
+### Teams
+
+Note: We mostly use Zoom for meetings and Slack for messaging in REG, but others at the Turing use Teams more heavily (e.g. the business team), and some projects have meetings there.
+
+- Get it from [the Microsoft site](https://teams.microsoft.com/downloads).
+  There is also a mobile app.
+- Make calls, group calls and share screen straightforwardly within the app.
+- You can find your VoIP number by looking at your "My Office profile" (office.com, then click your profile picture).
+  - Ask IT for one if you don't have one.
+- Calls to this number will ring in the Teams app.
+
+#### Some notes on using Teams
+
+Teams has several ways to share text and/or live voice and video with others:
+
+- calls
+- chats
+- meetings
+
+Calls and chats are between you and one or more of your "contacts".
+You can put your contacts into "groups", which are distinct from "teams".
+
+The most versatile option is a **meeting**.
+The way to make one of these in the Teams app is on the *calendar* tab (obviously!).
+It must be associated with a calendar event, and can be joined by people who are invited or by sharing a link.
+The meeting itself has a chat associated with it.
+It exists before and after the duration of the meeting, so can be used to set up persistent meeting spaces.
+
+## Wellbeing tips for remote working
+
+Remote working brings different challenges.
+The work-life boundaries are less clear and some people struggle with lack of connection.
+Here we collate tips that the group has found to positively impact their wellbeing while working remotely.
+At the beginning of the COVID-19 lockdowns, having wellbeing tips proved really useful, see below:
+For more information on Wellbeing in REG, see the [Wellbeing page](https://mathison.turing.ac.uk/page/2157?SearchId=380431).
+
+- **Delineate the start and end of the working day.**
+  A huge challenge is separating the working day from life outside of work, especially if both happen in the same location.
+  Suggestions that might help bound work to working hours:
+  - Simulate a commute to allow your brain to switch off.
+    For example, go for a 20 minute walk, run, or read a book.
+  - Have separate _work_ clothes and _non-work_ clothes.
+  - Tidy your laptop/screen away if you are using the same space for relaxation.
+  - If possible use a different device for leisure activity to your work machine.
+- **Finish on time.**
+  Without the impetus of having colleagues around you clocking off it seems easy to work later than usual and eat into your relaxation time.
+  Take a 1hr lunch break, and finish on time.
+  If you are finding that you are repeatedly doing this then there is an issue with your workload that needs to be corrected.
+  Reach out!
+- **Talk**.
+  Many of us have missed the casual connection you get with being around people, and when you are working alone it is easy to forget the you are part of a team.
+  This point is just a reminder that you work in a team that genuinely cares about the wellbeing of every member of the group.


### PR DESCRIPTION
## Summary

Migrates the Remote Working page from the REG Wiki to the REG handbook. The links have been updated so they now all point to the REGistry.

## Related issues

- Closes #alan-turing-institute/research-engineering-group/issues/39
- Contributes to #21
