### PR TITLE
Expenses from Hut23 wiki to Handbook

### DIFF
--- a/content/docs/working_at_the_turing/expenses.md
+++ b/content/docs/working_at_the_turing/expenses.md
@@ -1,0 +1,31 @@
+---
+# Page title as it appears in the navigation menu
+title: "Expenses"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 1
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Expenses
+
+Out-of-pocket expenses should be reclaimed using Certify. You should submit an expense claim on Certify for expenses incurred within a given month as soon as possible after that month ends, and no later than 60 days after the expense is incurred (except for visa costs, which can be claimed up to a year after starting employment)
+
+In the first instance, look at the information provided by the Finance team about how to use Certify on Mathison:
+
+https://mathison.turing.ac.uk/Interact/Pages/Content/Document.aspx?id=2169
+
+(This also includes links to Certify's own user guides and videos)
+
+
+# Related content
+
+- [REG-specific information](https://github.com/alan-turing-institute/research-engineering-group/wiki/Reclaiming-out-of-pocket-expenses)
+- [Certify Guidance on Mathison](https://mathison.turing.ac.uk/Interact/Pages/Content/Document.aspx?id=2169)
+- [REG-specific Finance codes](https://github.com/alan-turing-institute/research-engineering-group/wiki/REG-specific-finance-codes)
+- [REG-budget-and-project-codes](https://github.com/alan-turing-institute/research-engineering-group/wiki/REG-budget-and-project-codes)
+- [Cost recovery model](https://github.com/alan-turing-institute/Hut23/wiki/REG-cost-recovery) (REG access only)

--- a/content/docs/working_at_the_turing/expenses.md
+++ b/content/docs/working_at_the_turing/expenses.md
@@ -13,7 +13,7 @@ weight: 1
 
 # Expenses
 
-Out-of-pocket expenses should be reclaimed using Certify. You should submit an expense claim on Certify for expenses incurred within a given month as soon as possible, and no later than 60 days after the expense is incurred (except for visa costs, which can be claimed up to a year after starting employment)
+Out-of-pocket expenses should be reclaimed using Certify. You should submit an expense claim on Certify for expenses incurred within a given month as soon as possible, and no later than 60 days after the expense is incurred (except for visa costs, which can be claimed up to a year after starting employment).
 
 In the first instance, look at the information provided by the Finance team about how to use Certify on Mathison:
 

--- a/content/docs/working_at_the_turing/expenses.md
+++ b/content/docs/working_at_the_turing/expenses.md
@@ -21,8 +21,7 @@ https://mathison.turing.ac.uk/Interact/Pages/Content/Document.aspx?id=2169
 
 (This also includes links to Certify's own user guides and videos)
 
-
-# Related content
+## Related content
 
 - [REG-specific information](https://github.com/alan-turing-institute/research-engineering-group/wiki/Reclaiming-out-of-pocket-expenses)
 - [Certify Guidance on Mathison](https://mathison.turing.ac.uk/Interact/Pages/Content/Document.aspx?id=2169)

--- a/content/docs/working_at_the_turing/expenses.md
+++ b/content/docs/working_at_the_turing/expenses.md
@@ -13,7 +13,7 @@ weight: 1
 
 # Expenses
 
-Out-of-pocket expenses should be reclaimed using Certify. You should submit an expense claim on Certify for expenses incurred within a given month as soon as possible after that month ends, and no later than 60 days after the expense is incurred (except for visa costs, which can be claimed up to a year after starting employment)
+Out-of-pocket expenses should be reclaimed using Certify. You should submit an expense claim on Certify for expenses incurred within a given month as soon as possible, and no later than 60 days after the expense is incurred (except for visa costs, which can be claimed up to a year after starting employment)
 
 In the first instance, look at the information provided by the Finance team about how to use Certify on Mathison:
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Please use this pull request template to describe the changes you have made.

- Make sure that you give your pull request a meaningful title.
- If this work is not ready to merge yet, please make it a draft pull request.
- Make sure that your branch is up-to-date with main.
- There is no need to add labels to your pull request.
- You can assign particular reviewers if you want to, but there is no need to.

Note that text in html comments will not be rendered.
-->

## Summary

Moving parts of [out-of-pocket-expenses](https://github.com/alan-turing-institute/research-engineering-group/wiki/Reclaiming-out-of-pocket-expenses) from the wiki to the handbook. 

We decided to keep the "Turing's Expense system" section and the links in "Related Content" for the handbook and leave the rest for the Wiki, as it's REG-specific. 

## Related issues
<!--
If this pull request fixes any issues please list theme here, for example

- Closes #42
- Closes #237

If this pull request contributes to any issues without closing them please also
list them, for example

- Contributes to #42
- Contributes to #237

Note that if the issue is in a different repo, you will need to specify the full path
in the format OWNER/REPOSITORY#ISSUE-NUMBER, for example:

- Contributes to octo-org/octo-repo#100
-->

Contributes to alan-turing-institute/research-engineering-group#32


