### PR TITLE
Add probation review page to handbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ resources
 node_modules/
 yarn.lock
 package.json
+
+.DS_Store

--- a/content/docs/communications/_index.md
+++ b/content/docs/communications/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Communications"
-weight: 6
+weight: 7
 ---
 
 # Communications

--- a/content/docs/employee_processes/_index.md
+++ b/content/docs/employee_processes/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Employee processes"
+weight: 3
+---
+
+# Employee processes

--- a/content/docs/employee_processes/probation.md
+++ b/content/docs/employee_processes/probation.md
@@ -49,7 +49,7 @@ This is purely an opportunity to identify any rare cases where we have clearly a
 
 All line managers should evaluate whether they feel each of their reports completing probation was appointed at the right 1/3 of the salary band for their role and complete the [probation completion form](https://github.com/alan-turing-institute/Hut23/tree/master/development/probation-completion-form.md) and send to the Principal in their reporting line and the REG Director.
 
-As with progression award recommendations made as part of the annual appraisal process, the final decision on whether a salary adjustment will be made lies with the REG Director, subject to approval by Institute Senior Management. 
+As with progression award recommendations made as part of the annual appraisal process, the final decision on whether a salary adjustment will be made lies with the REG Director, subject to approval by Institute Senior Management.
 
 ### Annual appraisal
 

--- a/content/docs/employee_processes/probation.md
+++ b/content/docs/employee_processes/probation.md
@@ -1,0 +1,60 @@
+---
+# Page title as it appears in the navigation menu
+title: "Probation"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 3
+---
+
+# Probation
+
+During the initial 6 months in a team member's appointment to the institute, they will undergo probation review with their line manager. (Note that if an existing team member was previously in another role at the Turing and underwent probation review in that role, they do not require a probation review when appointed to a role in REG.) This is designed to integrate with the on-boarding process to ensure that new team members are performing their job as expected. This wiki page outlines the expectations for team members and line managers in going through the probation process.
+
+Turing-wide information on probation can be found on Mathison:
+
+- [Probation Policy](https://mathison.turing.ac.uk/Utilities/Uploads/Handler/Uploader.ashx?area=composer&filename=Probation+Policy+HRPOL017+V1.0.pdf&fileguid=070ff12d-845c-400d-9826-bac27fa5b3ad)
+- [Probation FAQs](https://mathison.turing.ac.uk/Utilities/Uploads/Handler/Uploader.ashx?area=composer&filename=Probation+Period+Training+FAQs.pdf&fileguid=bb062c31-018f-4eee-8fc3-6e74c56addb8)
+
+## Information for team members on probation
+
+Probation in REG is a lightweight review process that will ensure you are settling into the role and performing as expected. Turing policy is that such reviews should occur with meetings at 3 weeks, 3 months, and 5 months from the team member's start date, with a final recommendation at 6 months:
+
+- **3 weeks:** Create a set of initial probation objectives once the team member has settled in. Note that you might not have a clear project or projects to work on at this point, so it is fine to refine any objectives set now at the subsequent reviews. Your manager can help you set appropriate objectives.
+- **3 months:** Initial review of progress towards your probation objectives. Your line manager will solicit feedback from people you have worked with to ensure you are settling into the team. You may need to revise your objectives to adjust for changes in the projects you have been working on, which is very normal.
+- **5 months:** Final review prior to end of probation. The timing of this review is designed to give one last chance for actionable feedback to someone that is underperforming. In cases where someone is underperforming the most likely action to be taken at this time is to extend probation for an additional 3 months.
+- **6 months:** Recommendation is made to pass probation, or to extend if the team member would benefit from additional time to settle into the role.
+
+Upon passing probation, the REG Leadership Team (Director and the Principals) will review your salary to ensure you are fairly placed relative to your peers. Juniors will not undergo pay review, as we have a separate process for development and promotion for Juniors, summarised below. See the wiki page on [[Annual-pay-increases]] for more information on the REG philosophy and principles for pay and progression, and additional information specific to the end of probation review below.
+
+## Additional Probation Information for Juniors
+
+Because the Junior role is slightly different from REG roles at Standard and above, Juniors have their growth and development monitored more closely. Juniors are assessed at the end of probation as all members of the team following the description above, but have additional promotion reviews at roughly 6 month intervals to monitor their growth and development. The first promotion review occurs after the Junior has been on the team for roughly one year, and it is at this time that the Junior's pay will be adjusted if they are growing and developing as expected (either through promotion to standard, or giving a development pay increase if they are growing in the role but not ready for promotion to Standard). This ensures that Juniors have their pay reviewed as frequently as all team members and are promoted to Standard as soon as they are ready.
+
+## Probation information for line managers
+
+As a manager, you are expected to help guide your report through their initial project work (or other team activities if they are not assigned to a project) and ensure their probation objectives are appropriate for their role. You should be gathering regular feedback from the team member's collaborators (ideally someone more senior than them) and passing on information on their work and giving any constructive feedback. If all is going well, a quick message to the reviewers every few weeks to confirm that all is okay should be fine, and you should pass this information on in your regular 1/1s with the team member.
+
+At 3 months, you will hold a mid-term probation review, which should simply be a slightly more formal version of the ongoing feedback on their performance. If the team member did not have a project initially, then this is a good opportunity to revisit the initial objectives and ensure they reflect the work expected of the team member. This is also a good opportunity to ensure they are participating in team events like Tech Talks, integrating socially with the team (particularly if they are not regularly working in the office), and are contributing to a Service Area.
+
+At 5 months, you will hold a second review. This review is mostly to ensure that any performance issues are communicated well in advance of the 6 month deadline (see below), but should be similar to the 3 month review.
+
+If you do hear any concerns about the team member's performance, it is *very* important to follow up on this promptly. Because REG is a learning team, people are frequently working in unfamiliar territory and it can be difficult to recognise that they can ask for help when they are struggling and it is not a reflection on their performance. The team member could also be facing a difficult situation outside of work -- if they are not comfortable sharing their situation with you, then refer them to the [Turing's wellbeing support services](https://mathison.turing.ac.uk/page/2228), HR or the [Turing's External Supervisor](https://mathison.turing.ac.uk/page/3052). If there are problems with the team member's performance and the manager is not comfortable giving this feedback to the team member, then it is best to ask for help from the Principal into whom you report. If there are still problems with the team member's performance at the 5 month review, then you should speak to the Principal in your reporting line.
+
+## Post-probation salary review points
+
+### End of probation review
+
+At the end of probation, REG will conduct a salary review of all Standard and above team members passing probation. Junior staff will have their salary reviewed 12 months after appointment as part of their first promotion review (see additional information above).
+
+This is purely an opportunity to identify any rare cases where we have clearly and significantly mis-levelled a new starter on initial appointment to the team. Changes to salary will only be made in exceptional circumstances to adjust the team member's placement in the band to correct a significant misalignment and where it would not be fair to wait to the next annual appraisal to address this.
+
+All line managers should evaluate whether they feel each of their reports completing probation was appointed at the right 1/3 of the salary band for their role and complete the [probation completion form](https://github.com/alan-turing-institute/Hut23/tree/master/development/probation-completion-form.md) and send to the Principal in their reporting line and the REG Director.
+
+As with progression award recommendations made as part of the annual appraisal process, the final decision on whether a salary adjustment will be made lies with the REG Director, subject to approval by Institute Senior Management. 
+
+### Annual appraisal
+
+From the 2023-24 appraisal year, all REG staff who have completed probation on or before 31 May will be eligible for a progression award as part of the annual appraisal process, with these awards pro-rated for those in-post less than 12 months.
+
+All employees who complete probation on or before 31 January will go through the standard appraisal process on the HR system (Cezanne). Those completing probation between 01 February and 31 May will not be included in the formal appraisal process on the HR system but, for REG, line managers will perform a similar appraisal of performance as for those staff who are going through the formal appraisal process and will make a recommendation for a progression award on the same basis as for those going through the formal appraisal process. Whether undergoing the formal or informal appraisal process, **progression awards will be pro-rated for staff with less than 12 months of service**. See the [Performance Review Guide](https://mathison.turing.ac.uk/page/2319) for more information.
+
+See the [REG Appraisal Guide](https://github.com/alan-turing-institute/research-engineering-group/wiki/Annual-appraisals) for details of how the appraisal process (formal or informal) is run in REG. Note that progression awards made as part of the annual appraisal process are separate to the universal unconditional cost of living increase awarded to all employees, regardless of probation status, each April. See the [annual pay increases](https://github.com/alan-turing-institute/research-engineering-group/wiki/Annual-pay-increases) page for details of cost of living and progression awards from previous years.

--- a/content/docs/how_we_work/_index.md
+++ b/content/docs/how_we_work/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "How we work"
-weight: 3
+weight: 4
 ---
 
 # How We Work

--- a/content/docs/technical_practices/_index.md
+++ b/content/docs/technical_practices/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Common Technical Practices"
-weight: 5
+weight: 6
 ---
 
 # Common Technical Practices

--- a/content/docs/working_at_the_turing/_index.md
+++ b/content/docs/working_at_the_turing/_index.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Working at The Turing"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 4
+weight: 5
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the changes. -->
Adds probation review page to handbook. 
See https://github.com/alan-turing-institute/research-engineering-group/issues/26

## Related issues

Contributes to alan-turing-institute/research-engineering-group#26