### PR TITLE
Adding REG-internal links from the Wiki to the Handbook

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,6 +20,23 @@ disableKinds = ['taxonomy', 'taxonomyTerm']
 
 # After ToC
 [[menu.after]]
+  name = 'REG internal links'
+  weight = 10
+
+  [[menu.after]]
+    parent = 'REG internal links'
+    name = 'Subitem 1 on wiki'
+    url = 'https://www.turing.ac.uk/research-engineering/subitem1'
+    weight = 1
+
+  # Another sub-item
+  [[menu.after]]
+    parent = 'REG internal links'
+    name = 'Subitem 2 on wiki'
+    url = 'https://www.turing.ac.uk/research-engineering/subitem2'
+    weight = 2
+
+[[menu.after]]
   name = 'Research Engineering'
   url = 'https://www.turing.ac.uk/research-engineering'
   weight = 10


### PR DESCRIPTION
This is a simple edit of the `config.toml` to show how to link pages as subheadings in the table of contents. When we know what should stay internal/external to the Wiki, we can add the Wiki links here so they are shown as subheadings in the handbook.