### PR TITLE
Convert fixed line breaks to semantic line breaks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,5 +105,5 @@ jobs:
         run: |
           htmlproofer ./public \
           --swap-urls "^https\://alan-turing-institute.github.io/REG-handbook/:/,^/REG-handbook/:/,/edit/main:/edit/$(git branch --show-current)" \
-          --ignore-urls '/REG-handbook,/turing.ac.uk/,/github.com/,/docs.github.com/' \
+          --ignore-urls '/REG-handbook,/turing.ac.uk/,/github.com/,/docs.github.com/,/twitter.com/' \
           --ignore-files './public/docs/contributors/index.html'

--- a/content/docs/contributing/_index.md
+++ b/content/docs/contributing/_index.md
@@ -5,8 +5,7 @@ weight: 99
 
 # Contributing
 
-This section contains a guide for contributing to the handbook. It is not a
-comprehensive guide to Hugo or any of the other tools used. Instead it is aimed
-to be a user-focused guide explaining how add to or edit the handbook without
-dwelling on the details of the underlying technologies. For those interesting in
-learning more, links will be liberally placed throughout for further reading.
+This section contains a guide for contributing to the handbook.
+It is not a comprehensive guide to Hugo or any of the other tools used.
+Instead it is aimed to be a user-focused guide explaining how add to or edit the handbook without dwelling on the details of the underlying technologies.
+For those interested in learning more, links will be liberally placed throughout for further reading.

--- a/content/docs/contributing/advanced.md
+++ b/content/docs/contributing/advanced.md
@@ -15,35 +15,23 @@ weight: 7
 
 ## Using Data
 
-Through using templates Hugo can [build page content from
-datafiles](https://gohugo.io/templates/data-templates/). This is particularly
-useful for when you want to display structured data in a page and when it would
-be easier to maintain a datafile rather than a Markdown or HTML document.
+Through using templates Hugo can [build page content from datafiles](https://gohugo.io/templates/data-templates/).
+This is particularly useful for when you want to display structured data in a page and when it would be easier to maintain a datafile rather than a Markdown or HTML document.
 
 ## Creating Shortcodes
 
-It is possible to [create your own
-shortcodes](https://gohugo.io/templates/shortcode-templates/). These should be
-placed in {{% repo_link path="layouts/shortcodes/" text="`layouts/shortcodes/`"
-%}}.
+It is possible to [create your own shortcodes](https://gohugo.io/templates/shortcode-templates/).
+These should be placed in {{% repo_link path="layouts/shortcodes/" text="`layouts/shortcodes/`" %}}.
 
-If you feel the need to use HTML or want to create page content from a datafile
-(like a YAML file or csv) then a shortcode is probably the right answer.
+If you feel the need to use HTML or want to create page content from a datafile (like a YAML file or csv) then a shortcode is probably the right answer.
 
-You should refer to Hugo's [templates](https://gohugo.io/templates/) and
-[functions](https://gohugo.io/functions/) documentation for resources to help
-writing a shortcode.
+You should refer to Hugo's [templates](https://gohugo.io/templates/) and [functions](https://gohugo.io/functions/) documentation for resources to help writing a shortcode.
 
 ## Partial Templates
 
-Whole page templates are built from of a number of smaller [partial
-templates](https://gohugo.io/templates/partials/). This approach reduces
-repeated code in templates and help keep making changes simple.
+Whole page templates are built from of a number of smaller [partial templates](https://gohugo.io/templates/partials/).
+This approach reduces repeated code in templates and help keep making changes simple.
 
-The theme defines a number of dummy [partial
-templates](https://github.com/alex-shpak/hugo-book#partials) for us to
-overwrite.
+The theme defines a number of dummy [partial templates](https://github.com/alex-shpak/hugo-book#partials) for us to overwrite.
 
-For example, the Creative Commons notice at the bottom of each page was added by
-editing {{% repo_link path="layouts/partials/docs/inject/footer.html"
-text="`layouts/partial/docs/inject/footer.html`" %}}.
+For example, the Creative Commons notice at the bottom of each page was added by editing {{% repo_link path="layouts/partials/docs/inject/footer.html" text="`layouts/partial/docs/inject/footer.html`" %}}.

--- a/content/docs/contributing/contributing_changes.md
+++ b/content/docs/contributing/contributing_changes.md
@@ -34,8 +34,7 @@ This will make it easier to merge changes from many contributors.
 Try to pick a branch name which is short and describes the change you are making.
 
 {{% hint warning %}}
-The changes on one branch or pull request should address a
-single issue and be self-contained.
+The changes on one branch or pull request should address a single issue and be self-contained.
 Don't try to solve more than one unrelated problem at once.
 
 Sticking to this practice will help ensure pull requests are small and easy to review.

--- a/content/docs/contributing/creating_a_page.md
+++ b/content/docs/contributing/creating_a_page.md
@@ -15,22 +15,16 @@ weight: 3
 
 ## How Hugo Arranges Content
 
-Pages are build from content files in the {{% repo_link path="content/"
-text="`content/`" %}} directory. Hugo automatically gives pages a URL based on
-the organisation of files in the `content/` directory.
+Pages are built from content files in the {{% repo_link path="content/" text="`content/`" %}} directory.
+Hugo automatically gives pages a URL based on the organisation of files in the `content/` directory.
 
-In Hugo, the first directory after `content/` is significant and [defines the
-content type](https://gohugo.io/content-management/sections/). All handbook
-pages should be nested in the `content/docs/` directory.
+In Hugo, the first directory after `content/` is significant and [defines the content type](https://gohugo.io/content-management/sections/).
+All handbook pages should be nested in the `content/docs/` directory.
 
-Sections may be created in `content/docs/` (to any depth) by creating a
-directory containing a content file called `_index.md`.
+Sections may be created in `content/docs/` (to any depth) by creating a directory containing a content file called `_index.md`.
 
 {{% hint warning %}}
-It is important that the index file exists for Hugo to [correctly assign pages
-to sections](https://gohugo.io/content-management/sections/) and
-for the [theme](https://github.com/alex-shpak/hugo-book) to arrange pages in the
-tree-like menu.
+It is important that the index file exists for Hugo to [correctly assign pages to sections](https://gohugo.io/content-management/sections/) and for the [theme](https://github.com/alex-shpak/hugo-book) to arrange pages in the tree-like menu.
 {{% /hint %}}
 
 ## Creating a New Page
@@ -49,16 +43,13 @@ hugo new content/docs/contributing/creating_a_page.md
 
 Hugo will create a new Markdown document at the path you specified.
 
-Hugo provides a convenient way to generate new pages from templates called
-[Archetypes](https://gohugo.io/content-management/archetypes/). You can see the
-archetypes in the {{% repo_link path="archetypes" text="`archetypes/` directory"
-%}}.
+Hugo provides a convenient way to generate new pages from templates called [Archetypes](https://gohugo.io/content-management/archetypes/).
+You can see the archetypes in the {{% repo_link path="archetypes" text="`archetypes/` directory" %}}.
 
-Because your document is in the `docs` directory, Hugo will look for an
-archetype called {{% repo_link path="archetypes/docs.md" text="`docs.md`" %}} to
-use as a template.
+Because your document is in the `docs` directory, Hugo will look for an archetype called {{% repo_link path="archetypes/docs.md" text="`docs.md`" %}} to use as a template.
 
-Now you can edit your page with your favourite text editor. For example
+Now you can edit your page with your favourite text editor.
+For example
 
 ```bash
 vim content/docs/contributing/creating_a_page.md
@@ -66,14 +57,12 @@ vim content/docs/contributing/creating_a_page.md
 
 ## Creating a Section
 
-We can also use the `hugo new` command to create a new section, both the
-directory and index file. For example
+We can also use the `hugo new` command to create a new section, both the directory and index file.
+For example
 
 ```bash
 hugo new content/docs/new_section/_index.md
 vim content/docs/new_section/_index.md
 ```
 
-If you only want a section to organise some pages and not to have a page of its
-own, you can simply leave the content section of `_index.md` (after the YAML
-front matter) empty.
+If you only want a section to organise some pages and not to have a page of its own, you can simply leave the content section of `_index.md` (after the YAML front matter) empty.

--- a/content/docs/contributing/discussions_and_issues.md
+++ b/content/docs/contributing/discussions_and_issues.md
@@ -13,23 +13,20 @@ weight: -2
 
 # Discussions and Issues
 
-Contributing does not only mean adding code or writing pages. Being involved in
-reporting issues and discussing ideas are important and valuable aspects to
-contributing. The handbook uses both issues and discussions on GitHub.
+Contributing does not only mean adding code or writing pages.
+Being involved in reporting issues and discussing ideas are important and valuable aspects to contributing.
+The handbook uses both issues and discussions on GitHub.
 
 ## Discussions
 
-[The handbook
-Discussions](https://github.com/alan-turing-institute/REG-handbook/discussions)
-are the best place for informal talk about the handbook.
+[The *Discussions* on the handbook repository](https://github.com/alan-turing-institute/REG-handbook/discussions) are the best place for informal talk about the handbook.
 
-You should feel welcome to create a discussion on any relevant topic, without
-the formality of an issue.
+You should feel welcome to create a discussion on any relevant topic, without the formality of an issue.
 
 Good examples of discussions are
 
 - Any questions
-- Possible bugs (does anyone else have this problem?)
+- Possible bugs ('does anyone else have this problem?')
 - Chapter suggestions
 - Looking for collaborators
 - Community support
@@ -37,13 +34,10 @@ Good examples of discussions are
 
 ## Issues
 
-[The issue
-tracker](https://github.com/alan-turing-institute/REG-handbook/issues) is best
-used for development work. This is because issues integrate well with GitHub
-development tools like projects, pull requests, assignments and so on.
+[The issue tracker](https://github.com/alan-turing-institute/REG-handbook/issues) is best used for development work.
+This is because issues integrate well with GitHub development tools like projects, pull requests, assignments and so on.
 
-Each issue should ideally represent a well-defined,
-self-contained piece of work suitable to become a single pull request.
+Each issue should ideally represent a well-defined, self-contained piece of work suitable to become a single pull request.
 
 Good examples of issues are
 
@@ -52,5 +46,4 @@ Good examples of issues are
 - Feature requests (such as new shortcodes)
 - Specific ideas for changes
 
-When opening an issue, pick a suitable template (if any) to make the process
-easier.
+When opening an issue, pick a suitable template (if any) to make the process easier.

--- a/content/docs/contributing/editing_a_page.md
+++ b/content/docs/contributing/editing_a_page.md
@@ -13,24 +13,19 @@ weight: 4
 
 # Editing a Page
 
-If you followed the instructions in the [Getting Started section]({{% ref
-"getting_started.md" %}}) to checkout the repository and serve the handbook
-locally you can edit a page locally. However, as you may have noticed, at the
-bottom of each page is a link to edit the page in the GitHub web editor if you
-would prefer. This may be easy for making small changes.
+If you followed the instructions in the [Getting Started section]({{% ref "getting_started.md" %}}) to checkout the repository and serve the handbook locally you can edit a page locally.
+However, as you may have noticed, at the bottom of each page is a link to edit the page in the GitHub web editor if you would prefer.
+This may be easy for making small changes.
 
 ## Pages
 
-Each page is a [Markdown](https://www.markdownguide.org/) file with
-[YAML](https://yaml.org/) front matter followed by the page contents in
-Markdown.
+Each page is a [Markdown](https://www.markdownguide.org/) file with [YAML](https://yaml.org/) front matter followed by the page contents in Markdown.
 
 ### Front Matter
 
-The [front matter](https://gohugo.io/content-management/front-matter/) is used
-to define various pieces of metadata related to a page. The front matter appears
-at the top of a content file. In the handbook we format front matter as YAML,
-preceded and followed by three hyphens.
+The [front matter](https://gohugo.io/content-management/front-matter/) is used to define various pieces of metadata related to a page.
+The front matter appears at the top of a content file.
+In the handbook we format front matter as YAML, preceded and followed by three hyphens.
 
 ```yaml
 ---
@@ -39,17 +34,14 @@ weight: 1
 ---
 ```
 
-The [full YAML specification](https://yaml.org/spec/1.2.2/) is long and
-comprehensive. The most important thing to understand here is that the front
-matter YAML consists of keys and values separated by a hyphen. For example, in
-the expression `weight: 1`, `weight` is the key with a value of `1`.
+The [full YAML specification](https://yaml.org/spec/1.2.2/) is long and comprehensive.
+The most important thing to understand here is that the front matter YAML consists of keys and values separated by a hyphen.
+For example, in the expression `weight: 1`, `weight` is the key with a value of `1`.
 
-If you created a page using `hugo new` then some boilerplate front matter with
-explanatory comments should already be present. If you are editing an existing
-page there should already be front matter.
+If you created a page using `hugo new` then some boilerplate front matter with explanatory comments should already be present.
+If you are editing an existing page there should already be front matter.
 
-Most of the time, the only keys you will need to consider are `title` and
-`weight`.
+Most of the time, the only keys you will need to consider are `title` and `weight`.
 
 `title`
 : The title of a page as it appears in the navigation menu
@@ -58,8 +50,7 @@ Most of the time, the only keys you will need to consider are `title` and
 : Determines the order of pages in the navigation menu. Smaller numbers appear
 first
 
-The Hugo documentation details a set of [predefined front matter
-keys](https://gohugo.io/content-management/front-matter/#front-matter-variables).
+The Hugo documentation details a set of [predefined front matter keys](https://gohugo.io/content-management/front-matter/#front-matter-variables).
 Other valid fields related to the handbook theme are documented in the [theme's
 README](https://github.com/alex-shpak/hugo-book#page-configuration).
 
@@ -76,22 +67,18 @@ weight: 1
 | content section |
 ```
 
-The content section is formatted in Markdown. Markdown Guide outlines the
-[basic](https://www.markdownguide.org/basic-syntax/) and
-[extended](https://www.markdownguide.org/extended-syntax/).
+The content section is formatted in Markdown.
+The following links from Markdown Guide describe [basic](https://www.markdownguide.org/basic-syntax/) and [extended](https://www.markdownguide.org/extended-syntax/) Markdown syntax.
 
 {{% hint warning %}}
-Not all of the extended Markdown syntax may be implemented by Hugo's [Markdown
-renderer](https://gohugo.io/getting-started/configuration-markup)
+Not all of the extended Markdown syntax may be implemented by Hugo's [Markdown renderer](https://gohugo.io/getting-started/configuration-markup).
 {{% /hint %}}
 
 ### Shortcodes
 
-[Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugos-built-in-shortcodes)
-are templates (which can be parametrised) and included the content section. They
-can be particularly useful for including more complex features than Markdown's
-simple syntax will allow. Using a shortcode is preferable to including raw HTML
-in a content file.
+[Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugos-built-in-shortcodes) are templates (which can be parametrised) and included the content section.
+They can be particularly useful for including more complex features than Markdown's simple syntax will allow.
+Using a shortcode is preferable to including raw HTML in a content file.
 
 Shortcodes can called in Markdown content files the following way
 
@@ -107,8 +94,7 @@ Some shortcodes may have an opening and closing tag, similar to HTML
 
 #### Hugo Shortcodes
 
-Hugo has a set of useful [built-in
-shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugos-built-in-shortcodes).
+Hugo has a set of useful [built-in shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugos-built-in-shortcodes).
 
 In particular
 
@@ -116,14 +102,11 @@ In particular
 - [gist](https://gohugo.io/content-management/shortcodes/#gist)
 - [highlight](https://gohugo.io/content-management/shortcodes/#highlight)
 - [param](https://gohugo.io/content-management/shortcodes/#param)
-- [ref and
-  relref](https://gohugo.io/content-management/shortcodes/#ref-and-relref)
+- [ref and relref](https://gohugo.io/content-management/shortcodes/#ref-and-relref)
 
 #### Theme Shortcodes
 
-The theme has a [number of
-shortcodes](https://github.com/alex-shpak/hugo-book#shortcodes) which may be
-helpful.
+The theme has a [number of shortcodes](https://github.com/alex-shpak/hugo-book#shortcodes) which may be helpful.
 
 In particular
 
@@ -134,8 +117,8 @@ In particular
 
 #### Repository Shortcodes
 
-Shortcodes can be included in the handbooks repository. For more information see
-[Creating Shortcodes]({{% ref "advanced.md#creating-shortcodes" %}})
+Shortcodes can be included in the handbooks repository.
+For more information see [Creating Shortcodes]({{% ref "advanced.md#creating-shortcodes" %}})
 
 ##### repo_link
 

--- a/content/docs/contributing/reviewing_changes.md
+++ b/content/docs/contributing/reviewing_changes.md
@@ -13,10 +13,9 @@ weight: 6
 
 # Reviewing Changes
 
-The review process helps to ensure high quality and catch problems in
-contributions. When acting as a reviewer, you should see your position as
-sharing your knowledge and working with the contributors to achieve the best
-possible result. Reviewing should **not** be an adversarial process.
+The review process helps to ensure high quality and catch problems in contributions.
+When acting as a reviewer, you should see your position as sharing your knowledge and working with the contributors to achieve the best possible result.
+Reviewing should **not** be an adversarial process.
 
 ## Recognising Contributions
 
@@ -25,54 +24,42 @@ See the [Recognising Contributions]({{< relref "/docs/contributing/recognising_c
 
 ## Code Quality
 
-As a reviewer, one of your jobs is to ensure the quality of the codebase remains
-high.
+As a reviewer, one of your jobs is to ensure the quality of the codebase remains high.
 
-The CI process will help to assess pull requests by subjecting each commit to a
-series of tests. Some tests are required to pass and will block merging until
-they do.
+The CI process will help to assess pull requests by subjecting each commit to a series of tests.
+Some tests are required to pass and will block merging until they do.
 
-Other tests are allowed to fail. This is because these tests check external
-hyperlinks which can fail for reasons out of our control. For example, a website
-being offline or a rate limiting API. However, you should always aim to have
-all tests passing and investigate why any test fails. In particular, a genuinely
-incorrect link should not be ignored.
+Other tests are allowed to fail.
+This is because these tests check external hyperlinks which can fail for reasons out of our control: for example, a website being offline, or an API rate limit.
+However, you should always aim to have all tests passing and investigate why any test fails.
+In particular, a genuinely incorrect link should not be ignored.
 
-You should **always** clone the branch, build the handbook locally (using `hugo
-server --minify`) and inspect the changes using your browser. Not all bugs will
-be caught by CI and not all changes will be obvious in the source files.
+You should **always** clone the branch, build the handbook locally (using `hugo server --minify`) and inspect the changes using your browser.
+Not all bugs will be caught by CI and not all changes will be obvious in the source files.
 
 ## Reviewing the Pull Request
 
-Use the [GitHub review
-system](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request)
-to check the diffs of all source files.
+Use the [GitHub review system](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request) to check the diffs of all source files.
 
-You should make use of [line
-comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request)
-where you have comments or questions about particular lines of sections. This
-gives context so that everyone knows where the problem is or what the question
-refers to.
+You should make use of [line comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) where you have comments or questions about particular lines of sections.
+This gives context so that everyone knows where the problem is or what the question refers to.
 
-Line comments can also be used to suggest changes (using the ± button). You
-should do this when you have a simple solution. This is an excellent way to
-share knowledge.
+Line comments can also be used to suggest changes (using the ± button).
+You should do this when you have a simple solution.
+This is an excellent way to share knowledge.
 
-When you are finished, [submit your
-review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request#submitting-your-review)
-making sure to choose "comment", "approve" or "request changes" as appropriate.
+When you are finished, [submit your review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request#submitting-your-review), making sure to choose "comment", "approve" or "request changes" as appropriate.
 
 ## Changes
 
-If you request changes, the pull request will enter an iterative process where
-the contributors make adjustments you repeat the review process.
+If you request changes, the pull request will enter an iterative process where the contributors make adjustments you repeat the review process.
 
-The contributors may accept your proposed changes, make their own changes or
-push back against changes. All of these may be appropriate. It is important to
-work together with the contributors to resolve any conversations. All
-conversations **must** be resolved before merging.
+The contributors may accept your proposed changes, make their own changes or push back against changes.
+All of these may be appropriate.
+It is important to work together with the contributors to resolve any conversations.
+All conversations **must** be resolved before merging.
 
 ## Merging
 
-Update your review status to "approve" when you are happy with the state of the
-pull request. When all reviewers are satisfied, merge the pull request.
+Update your review status to "approve" when you are happy with the state of the pull request.
+When all reviewers are satisfied, merge the pull request.

--- a/content/docs/how_we_work/meeting_record.md
+++ b/content/docs/how_we_work/meeting_record.md
@@ -13,46 +13,35 @@ weight: 2
 
 # Meeting Records
 
-When a synchronous meeting is unavoidable, it is critical to produce a clear and
-thorough record.
+When a synchronous meeting is unavoidable, it is critical to produce a clear and thorough record.
 
 The meeting record is important as a reference for what happened at the meeting.
-In particular, any decisions made or actions assigned need to be clearly
-recorded for future reference.
+In particular, any decisions made or actions assigned need to be clearly recorded for future reference.
 
-A good record will also be invaluable to anyone who was not able to attend an in
-person meeting.
+A good record will also be invaluable to anyone who was not able to attend an in-person meeting.
 
 ## Meeting Record Template
 
-Below is a suggested [template]({{% static_url url="meeting_record.md" %}}) for
-a meeting record document. The template uses
-[Pandoc](https://pandoc.org/MANUAL.html#variables-for-latex)
-[Markdown](https://pandoc.org/MANUAL.html#pandocs-markdown). Parts of the
-template are already filled with explanations of how they should be used.
+Below is a suggested [template]({{% static_url url="meeting_record.md" %}}) for a meeting record document.
+The template uses [Pandoc](https://pandoc.org/MANUAL.html#variables-for-latex) [Markdown](https://pandoc.org/MANUAL.html#pandocs-markdown).
+Parts of the template are already filled with explanations of how they should be used.
 
 {{% source_file file="static/meeting_record.md" language="md" %}}
 
-For printing or wider distribution, a meeting record following the template may
-be converted to pdf using Pandoc,
+For printing or wider distribution, a meeting record following the template may be converted to pdf using Pandoc,
 
 ```bash
 pandoc meeting_record.md -o meeting_record.pdf
 ```
 
-A Pandoc [YAML metadata
-block](https://pandoc.org/MANUAL.html#extension-yaml_metadata_block) at the top
-of the template contains metadata about the meeting and helps the record render
-into a good looking pdf document.
+A Pandoc [YAML metadata block](https://pandoc.org/MANUAL.html#extension-yaml_metadata_block) at the top of the template contains metadata about the meeting and helps the record render into a good-looking pdf document.
 
 ## How To Use
 
 - Create the meeting record document before the meeting.
-- Use a collaborative text editor like [HackMD](https://hackmd.io) so that all
-  attendees may edit the document.
+- Use a collaborative text editor like [HackMD](https://hackmd.io) so that all attendees may edit the document.
 - Circulate the document to allow others to add and agree on agenda items.
-- Distribute the record or store in a location visible to everyone who may need
-  to read it.
+- Distribute the record or store in a location visible to everyone who may need to read it.
 
-The template may also be used to avoid a meeting entirely. The document can be
-completed collaboratively and asynchronously while achieving the same result.
+The template may also be used to avoid a meeting entirely.
+The document can be completed collaboratively and asynchronously while achieving the same result.

--- a/content/docs/technical_practices/software_dev_best_practice.md
+++ b/content/docs/technical_practices/software_dev_best_practice.md
@@ -11,58 +11,41 @@ _Status:_ this document is a draft proposal.
 
 ## RSE projects
 
-- There should be a Github issue for each thing we do. It’s ok for issues to
-    evolve and my preference would be that the top description box always has
-    the most up to date, clearest description of the issue and its definition of
-    done. Feel free to make liberal use of the comments for communication and
-    tracking investigative / exploratory work. The main description box should
-    contain a clear definition of done / acceptance criteria sufficient for the
-    following to be done in principle by different people from the team who are
-    involved in the project.
-    - Implement the functionality
-    - Write tests to validate the implementation meets the definition of done
-    - Review the implementation for correctness
+- There should be a GitHub issue for each thing we do.
+  It’s ok for issues to evolve and my preference would be that the top description box always has the most up to date, clearest description of the issue and its definition of done.
+  Feel free to make liberal use of the comments for communication and tracking investigative / exploratory work.
+  The main description box should contain a clear definition of done / acceptance criteria sufficient for the following to be done in principle by different people from the team who are involved in the project.
+  - Implement the functionality
+  - Write tests to validate the implementation meets the definition of done
+  - Review the implementation for correctness
 
-- All code should have automated tests, with all tests runnable by a single
-    command by someone who has checked out a fresh copy of the repo.
+- All code should have automated tests, with all tests runnable by a single command by someone who has checked out a fresh copy of the repo.
 
-- All dependencies, installation, compilation etc should be scripted such that
-    these can be triggered by a single command by someone who has checked out a
-    fresh copy of the repo. Dependencies required only for testing can require a
-    second command or few.
+- All dependencies, installation, compilation etc should be scripted such that these can be triggered by a single command by someone who has checked out a fresh copy of the repo.
+  Dependencies required only for testing can require a second command or few.
 
-- Each new issue should be developed on a short-lived feature branch split
-    from “main”. These branches ideally only live around 0.5-2 days before
-    being merged back into main. Merge process should be: merge main into
-    feature branch and resolve any conflicts. Push latest feature branch to
-    Github. Open PR to merge into main after review + continuous integration
-    (CI) tests.
+- Each new issue should be developed on a short-lived feature branch split from "main".
+  These branches ideally only live around 0.5-2 days before being merged back into main.
+  Merge process should be: merge main into feature branch and resolve any conflicts. Push latest feature branch to GitHub.
+  Open PR to merge into main after review + continuous integration (CI) tests.
 
-- Code should be committed regularly in small chunks. You should generally be
-    committing multiple times per day. Commits on feature branches can have
-    broken functionality or tests, but all merges into main should only occur
-    at commits where the code is correct and has passing tests.
+- Code should be committed regularly in small chunks.
+  You should generally be committing multiple times per day.
+  Commits on feature branches can have broken functionality or tests, but all merges into main should only occur at commits where the code is correct and has passing tests.
 
-- All code commits should be accompanied by tests verifying it behaves as
-    expected. At a minimum code submitted as a PR should have tests that show it
-    meets the definition of done defined in the related issue(s). However, code
-    should have additional unit / regression / integration tests where
-    appropriate (it’s almost always appropriate). Writing code then tests is a
-    significantly lower quality assurance measure than writing tests first / in
-    iteration with the code, so you should do the latter.
+- All code commits should be accompanied by tests verifying it behaves as expected.
+  At a minimum code submitted as a PR should have tests that show it meets the definition of done defined in the related issue(s).
+  However, code should have additional unit / regression / integration tests where appropriate (it's almost always appropriate).
+  Writing code then tests is a significantly lower quality assurance measure than writing tests first / in iteration with the code, so you should do the latter.
 
-- All code should have had two eyeballs on it before it is merged into main,
-    either through pair programming or code review within the PR. Please note on
-    the PR who two eyes were. The second pair of eyes can be anyone on the
-    project (not just a coder), anyone in our team or someone from a related
-    team (e.g. the UCL research programming). Whether as pair programming or a
-    code review, the final PR code should be validated against the definition of
-    done detailed in the related issue(s) by the two pairs of eyes.
+- All code should have had two eyeballs on it before it is merged into main, either through pair programming or code review within the PR.
+  Please note on the PR who two eyes were.
+  The second pair of eyes can be anyone on the project (not just a coder), anyone in our team or someone from a related team (e.g. the UCL research programming).
+  Whether as pair programming or a code review, the final PR code should be validated against the definition of done detailed in the related issue(s) by the two pairs of eyes.
 
-- The Github repository should be set up to run all tests on all pushes to all
-    branches and on all PRs. Currently this can be done for public repos via
-    GitHub Actions. If CI is set up this way, commits to main should
-    be blocked unless all tests pass.
+- The GitHub repository should be set up to run all tests on all pushes to all branches and on all PRs.
+  Currently this can be done for public repos via GitHub Actions.
+  If CI is set up this way, commits to main should be blocked unless all tests pass.
 
 ## Data Science projects
 


### PR DESCRIPTION
## Summary

As title. The files listed in #68 have been converted to semantic line breaks.

I took the liberty to fix a couple of typos, and to also exclude Twitter from htmlproofer in CI since it is known to return 40x (this has been the case for many months but not fixed)

## Related issues

Closes #68