### PR TITLE
Update coffee chats to what we actually do nowadays

### DIFF
--- a/content/docs/regular_events/_index.md
+++ b/content/docs/regular_events/_index.md
@@ -13,16 +13,17 @@ weight: 1
 
 # Regular Events
 
-## Coffee Chats
-
-- [Coffee Chats]({{< relref "/docs/regular_events/coffee_chats.md" >}})
-
 ## REG Events
 
 - [Lunchtime tech talks]({{< relref "/docs/regular_events/lunchtime_tech_talks.md" >}})
 - [Lightning talks]({{< relref "/docs/regular_events/lightning_talks.md" >}})
 - [Reading groups]({{< relref "/docs/regular_events/reading_groups.md" >}})
+- [Open source hack sessions]({{< relref "/docs/regular_events/open_source_hacksessions.md" >}})
 
 ## Outward-facing Events
 
 - [Drop-in Sessions]({{< relref "/docs/regular_events/drop-in_sessions.md" >}})
+
+## Coffee Chats
+
+- [Randomised coffee chats]({{< relref "/docs/regular_events/coffee_chats.md" >}})

--- a/content/docs/regular_events/coffee_chats.md
+++ b/content/docs/regular_events/coffee_chats.md
@@ -1,8 +1,8 @@
 ---
 # Page title as it appears in the navigation menu
-title: "Coffee Chats"
+title: "Randomised Coffee Chats"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 1
+weight: 60
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu
@@ -11,8 +11,14 @@ weight: 1
 # bookSearchExclude = true
 ---
 
-# Coffee Chats
+# Randomised Coffee Chats
 
-The team has two optional, daily coffee chats at 08:45 and 13:45.
-The chats usually happen in Gather but there is also a Zoom room in case Gather is unavailable.
-Details for both rooms can be found [here](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#video-call-links).
+Approximately every 2 weeks, we partition REG into groups of 4 or 5 for informal chats.
+The groups are randomly generated (see the code [here](https://github.com/alan-turing-institute/randoffee/)) but generally try to ensure that everyone meets different people each week.
+
+If you have not signed up already and would like to join (or conversely if you would like to opt out), please inform the [people in charge of the random coffees](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry).
+
+{{% hint info %}}
+Several years ago, during the periods of lockdown, we used to have daily coffee chats at 08:45 and 13:45.
+These are very rarely used nowadays but the vestiges of these can still be seen in (for example) the daily notifications on Slack every morning.
+{{% /hint %}}

--- a/content/docs/regular_events/drop-in_sessions.md
+++ b/content/docs/regular_events/drop-in_sessions.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Drop-in Sessions"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 1
+weight: 50
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/regular_events/lightning_talks.md
+++ b/content/docs/regular_events/lightning_talks.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Lightning Talks"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 1
+weight: 20
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/regular_events/lunchtime_tech_talks.md
+++ b/content/docs/regular_events/lunchtime_tech_talks.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Lunchtime Tech Talks"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 1
+weight: 10
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/regular_events/open_source_hacksessions.md
+++ b/content/docs/regular_events/open_source_hacksessions.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Open Source Hacksessions"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 1
+weight: 40
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/regular_events/reading_groups.md
+++ b/content/docs/regular_events/reading_groups.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Reading Groups"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 1
+weight: 35
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu


### PR DESCRIPTION
## Summary

We haven't really done daily coffees for a long time. (Not since I started, at least, and I understand from people that it was a pandemic thing)

We are doing random, fortnightly, coffees now so I repurposed the coffee page to talk about this.

I also reordered the pages in the regular events section to match the categorisation in [`_index.md`](https://github.com/alan-turing-institute/REG-handbook/blob/coffee/content/docs/regular_events/_index.md).