### PR TITLE
Add EDI and wellbeing pages

### DIFF
--- a/content/docs/onboarding/new_joiners/checklist.md
+++ b/content/docs/onboarding/new_joiners/checklist.md
@@ -74,11 +74,8 @@ If anything is unclear, please figure it out by e.g. asking your buddies, and th
 - [ ] Message IT (ITServices@turing.ac.uk) to upgrade Zoom account from Basic to Pro
 - [ ] Send a short informal bio to the [REG newsletter owner](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#responsibilities).
 
-## New computer set-up
+## Sign up for ongoing activities
 
-- [ ] https://github.com/alan-turing-institute/research-engineering-group/wiki/Moving-to-a-new-computer
-
-## Ongoing activity sign-up
-
-- [ ] "Tech Talks" (Tuesdays 12:30pm), link on: https://github.com/alan-turing-institute/DataScienceSkills/wiki/Lunchtime-Tech-Talks
-- [ ] Read up about and you are recommended to join the [Society of Research Software Engineering](https://society-rse.org/), including the [Slack workspace](https://ukrse.slack.com/join/signup)
+- [ ] Feel free to put yourself down for a [tech talk]({{< ref "/content/docs/regular_events/lunchtime_tech_talks.md" >}}) (12:30 pm on Tuesdays): you can see if any open dates in [the schedule](https://github.com/alan-turing-institute/DataScienceSkills/wiki/Lunchtime-Tech-Talks) work for you, and then let [the person in charge of tech talks](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#responsibilities) know.
+- [ ] Read up about (and perhaps join---we recommend you do!) the [Society of Research Software Engineering](https://society-rse.org/), including the [Slack workspace](https://ukrse.slack.com/join/signup)
+- [ ] Sign up for any of the [EDI network groups]({{< ref "/content/docs/working_at_the_turing/edi.md#network-groups" >}}) which might interest you

--- a/content/docs/onboarding/new_joiners/checklist.md
+++ b/content/docs/onboarding/new_joiners/checklist.md
@@ -77,5 +77,5 @@ If anything is unclear, please figure it out by e.g. asking your buddies, and th
 ## Sign up for ongoing activities
 
 - [ ] Feel free to put yourself down for a [tech talk]({{< ref "/content/docs/regular_events/lunchtime_tech_talks.md" >}}) (12:30 pm on Tuesdays): you can see if any open dates in [the schedule](https://github.com/alan-turing-institute/DataScienceSkills/wiki/Lunchtime-Tech-Talks) work for you, and then let [the person in charge of tech talks](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#responsibilities) know.
-- [ ] Read up about (and perhaps join---we recommend you do!) the [Society of Research Software Engineering](https://society-rse.org/), including the [Slack workspace](https://ukrse.slack.com/join/signup)
+- [ ] Read up about (and perhaps join---we recommend you do!) the [Society of Research Software Engineering]({{< ref "/content/docs/onboarding/society_of_research_software_engineering.md " >}})
 - [ ] Sign up for any of the [EDI network groups]({{< ref "/content/docs/working_at_the_turing/edi.md#network-groups" >}}) which might interest you

--- a/content/docs/onboarding/new_joiners/checklist.md
+++ b/content/docs/onboarding/new_joiners/checklist.md
@@ -76,6 +76,6 @@ If anything is unclear, please figure it out by e.g. asking your buddies, and th
 
 ## Sign up for ongoing activities
 
-- [ ] Feel free to put yourself down for a [tech talk]({{< ref "/content/docs/regular_events/lunchtime_tech_talks.md" >}}) (12:30 pm on Tuesdays): you can see if any open dates in [the schedule](https://github.com/alan-turing-institute/DataScienceSkills/wiki/Lunchtime-Tech-Talks) work for you, and then let [the person in charge of tech talks](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#responsibilities) know.
-- [ ] Read up about (and perhaps join---we recommend you do!) the [Society of Research Software Engineering]({{< ref "/content/docs/onboarding/society_of_research_software_engineering.md " >}})
-- [ ] Sign up for any of the [EDI network groups]({{< ref "/content/docs/working_at_the_turing/edi.md#network-groups" >}}) which might interest you
+- [ ] Feel free to put yourself down for a [tech talk]({{< relref "/docs/regular_events/lunchtime_tech_talks.md" >}}) (12:30 pm on Tuesdays): you can see if any open dates in [the schedule](https://github.com/alan-turing-institute/DataScienceSkills/wiki/Lunchtime-Tech-Talks) work for you, and then let [the person in charge of tech talks](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#responsibilities) know.
+- [ ] Read up about (and perhaps join---we recommend you do!) the [Society of Research Software Engineering]({{< relref "../society_of_research_software_engineering.md" >}})
+- [ ] Sign up for any of the [EDI network groups]({{< relref "/docs/working_at_the_turing/edi.md#network-groups" >}}) which might interest you

--- a/content/docs/onboarding/society_of_research_software_engineering.md
+++ b/content/docs/onboarding/society_of_research_software_engineering.md
@@ -37,8 +37,7 @@ Their [Slack workspace](https://ukrse.slack.com/join/signup) contains plenty of 
 
 ## Claiming Back Subscriptions
 
-SocRSE membership is considered a professional subscription,
-which you're entitled to claim back as a REG member.
+SocRSE membership is considered a professional subscription, which you are entitled to claim back as a REG member.
 
 You should claim it back quickly after payment.
 Use Certify to claim it back following [these instructions](https://github.com/alan-turing-institute/research-engineering-group/wiki/Reclaiming-out-of-pocket-expenses#allocating-your-expenses-to-the-right-budget).

--- a/content/docs/working_at_the_turing/edi.md
+++ b/content/docs/working_at_the_turing/edi.md
@@ -1,0 +1,60 @@
+---
+# Page title as it appears in the navigation menu
+title: "Equality, Diversity, and Inclusion"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 3
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Equality, Diversity, and Inclusion
+
+## Overview
+
+The Turing has a strong commitment towards EDI, which is formally set out in the Institute's EDI [Strategy](https://www.turing.ac.uk/sites/default/files/2023-03/edi-strategy-report_v1.2_updated_16.03.2023_0.pdf) and [Action Plan](https://www.turing.ac.uk/sites/default/files/2021-09/edi-action-plan_final.pdf).
+For current Turing staff, you can also access an [EDI section on Mathison](https://mathison.turing.ac.uk/Interact/Pages/Section/Default.aspx?section=3684).
+
+## How to get involved
+
+If you are keen to be involved in the EDI work around REG and the Turing, do feel free to join the `#edi-equality-diversity-inclusion` channel on Slack, and/or contact:
+
+- in the first instance, [the people involved in the REG EDI service area.](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry)
+
+   Besides the people directly allocated to this service area, we also have a group of volunteers who are involved on a 'best-effort' basis.
+   You are welcome to join in any capacity!
+- [the Turing's dedicated EDI team](https://www.turing.ac.uk/about-us/equality-diversity-and-inclusion)
+
+Below we've described a handful of specific initiatives at the Turing which REG have been involved with.
+This list is not exhaustive (nor should it be: there is always more to be done!).
+
+### HDR UK Black Internship
+
+Since 2022 REG has been involved in hosting interns from the [Black Internship programme by Health Data Research UK](https://www.hdruk.ac.uk/study-and-train/train/health-data-science-black-internship-programme/).
+Interns have typically been involved with one health-related project from REG, plus many other activities around the Turing.
+You can see [a researcher spotlight on Olajumoke](https://www.turing.ac.uk/people/spotlights/olajumoke-olatunji), one of our interns from 2023.
+
+### EDI Annual Report
+
+Each year the Turing publishes an annual report (see [here](https://www.turing.ac.uk/sites/default/files/2023-02/edi_annual_report_october_2021-2022_public_version_002_1.pdf) for the most recent one, covering the period between October 2021 and September 2022), as well as a gender pay gap (see [here](https://www.turing.ac.uk/sites/default/files/2023-03/2023.03.30_gender_pay_gap_report.pdf)).
+REG typically assists the EDI team with analysis of the underlying data and recommendations on how to treat sensitive data.
+
+### Network Groups
+
+The Turing has set up four EDI network groups centred on specific topics, with the aim of providing feedback to the Institute's EDI team and senior management:
+
+- [Disability and Wellbeing](https://mathison.turing.ac.uk/page/2088)
+- [Gender Equality](https://mathison.turing.ac.uk/page/2089)
+- [LGBTQ+ Equality](https://mathison.turing.ac.uk/page/2090)
+- [Race Equality](https://mathison.turing.ac.uk/page/2091)
+
+REG members are strongly encouraged to participate in these groups.
+Additionally, group chairpersons (who can be from REG) are awarded an honorarium.
+
+### BCSWomen Lovelace Colloquium
+
+Since 2023, the Turing has been a sponsor for the [BCSWomen Lovelace Colloquium](https://bcswomenlovelace.bcs.org/), a one-day conference for women and non-binary students in computing fields.
+In 2023 REG sat on the careers panel and also (together with other teams from the Turing) had a stall at the conference.

--- a/content/docs/working_at_the_turing/wellbeing.md
+++ b/content/docs/working_at_the_turing/wellbeing.md
@@ -1,0 +1,16 @@
+---
+# Page title as it appears in the navigation menu
+title: "Wellbeing"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 4
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Wellbeing
+
+foo bar.

--- a/content/docs/working_at_the_turing/wellbeing.md
+++ b/content/docs/working_at_the_turing/wellbeing.md
@@ -13,4 +13,50 @@ weight: 4
 
 # Wellbeing
 
-foo bar.
+The Turing provides a number of support mechanisms to protect employees' wellbeing.
+
+The most up-to-date information can be found [on Mathison](https://mathison.turing.ac.uk/page/2228). A summary follows here:
+
+## Report + Support
+
+[Report + Support](https://reportandsupport.turing.ac.uk/) is an online platform where you can report cases of bullying, harassment, discrimination, assault, hate crime, sexual misconduct, or a breach of the Turing's values (Trust, Inclusivity, Respect, Leadership, Transparency, Integrity).
+Reports can be made anonymously if you so choose.
+
+## Care first
+
+All employees at the Turing can access the [Care first employee assistance programme](https://mathison.turing.ac.uk/page/2272).
+This includes a 24-hour phone counselling service, online counselling, and advice services.
+Contact details and links are available on the Mathison page.
+
+The employee assistance programme also provides access to the ['My Possible Self' app](https://www.mypossibleself.com/) for monitoring and improving mental health.
+
+## Private medical / dental insurance
+
+The Turing provides a [private medical insurance plan from Bupa](https://mathison.turing.ac.uk/page/3017).
+You have to opt in: if you want to sign up, contact HR with the information requested on the above Mathison page.
+You can choose to have either the medical insurance with or without the dental plan.
+
+The cost of the medical insurance itself is covered by the Turing, but you have to pay for the first £100 of treatment (this is called the 'excess'), and because this is a [taxable benefit](https://www.gov.uk/tax-company-benefits) you also have to pay tax on the cost of the medical insurance.
+The dental plan add-on has an annual flat rate charge.
+
+It is worth noting that the medical insurance includes cover for pre-existing conditions, as well as mental health, which means that you can use it to access therapy with counsellors or psychologists.
+You can use the [Bupa finder](https://www.finder.bupa.co.uk/) to search for recognised medical professionals.
+
+## Mental health first aiders
+
+There are a number of mental health first aiders in the Turing whom you can speak to and who can help you obtain support.
+A full list can be obtained [on Mathison](https://mathison.turing.ac.uk/page/2119).
+(Unfortunately, this does not yet include anyone in REG.)
+
+## External supervision
+
+All Turing staff have access to [individual, once-per-month sessions with an external supervisor, Debbie Dixon](https://mathison.turing.ac.uk/page/3052).
+External supervision is meant to provide participants with techniques and methods to navigate difficult situations, particularly at work.
+However, it is not a form of therapy and should not be seen as a replacement for that.
+
+## Free Headspace membership
+
+Headspace is an app for mindfulness and meditation.
+The Turing is a Headspace partner, meaning that all employees can access [free membership to Headspace](https://mathison.turing.ac.uk/page/2249).
+You can also add 5 other people to your membership for free.
+Instructions on how to access the Turing subscription can be found on the Mathison link above.


### PR DESCRIPTION
## Summary

Adds two new pages on

- [x] EDI
- [x] Wellbeing

within REG and in the wider Turing community.

## Related issues

Closes #132 

Indirectly closes: https://github.com/alan-turing-institute/Hut23/issues/1322

Indirectly closes: https://github.com/alan-turing-institute/Hut23/issues/1352