### PR TITLE
Add relocation and visa costs to list of FAQs

### DIFF
--- a/content/docs/how_we_work/knowledge_sharing.md
+++ b/content/docs/how_we_work/knowledge_sharing.md
@@ -83,7 +83,7 @@ If you have something you'd like to be included contact the [newsletter owner](h
 
 ### Hut23 Mailing List
 
-You should automatically be added to the `Hut23@turing.ac.uk` mailing list when you join REG (if not ask your line manager about it).
+You should automatically be added to the [Hut23 mailing list](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact) when you join REG (if not ask your line manager about it).
 This is often the best way to contact everyone in the team when organising events, or for other news/communication that should be a bit more permanent/formal than Slack and doesn't fit in an issue in the Hut23 repo.
 
 ## Less frequently or ad-hoc

--- a/content/docs/join_us/recruitment_FAQs.md
+++ b/content/docs/join_us/recruitment_FAQs.md
@@ -27,7 +27,7 @@ Questions are grouped by:
 
 ### Is the position open to applicants outside of the UK who do not currently have a UK working Visa but could obtain one?
 
-Yes, the positions are open to applicants outside the UK and our HR Team (HR@turing.ac.uk) will be able to offer you additional information on the process of obtaining a working Visa.
+Yes, the positions are open to applicants outside the UK and our [HR Team](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact) will be able to offer you additional information on the process of obtaining a working Visa.
 
 ### Are you accepting remote applicants?
 

--- a/content/docs/join_us/recruitment_FAQs.md
+++ b/content/docs/join_us/recruitment_FAQs.md
@@ -51,6 +51,14 @@ If you applied and did not get selected to interview you are welcome to apply ag
 If you applied and were unsuccessful at the interview stage, you are welcome to reapply if your profile has significantly progressed since the interview (new projects, job roles or other sources of experience).
 In general, we suggest to wait for at least one year before applying again.
 
+### Does the Turing cover relocation and visa costs?
+
+Yes.
+The Turing recognises that relocating and applying for a visa have different associated costs and therefore will provide support for both.
+All claims should be submitted within a year of the employment start date to Finance.
+For existing staff, visa claims should be submitted within one year of the visa renewal or amendment.
+More information can be found on [Mathison](https://mathison.turing.ac.uk/Interact/Pages/Section/ContentListing.aspx?subsection=4141&utm_source=interact&utm_medium=quick_search&utm_term=relocation).
+
 ## Profile
 
 ### Are there particular domains or skill sets that you are interested in for these roles?

--- a/content/docs/onboarding/new_joiners/checklist.md
+++ b/content/docs/onboarding/new_joiners/checklist.md
@@ -71,7 +71,7 @@ If anything is unclear, please figure it out by e.g. asking your buddies, and th
 - [ ] Have a look at the [Service areas](https://github.com/alan-turing-institute/research-engineering-group/wiki/Service-areas). There is no pressure to join one right away so you can take some time talking to people and finding an area that interests you.
 - [ ] Add the [shared REG Calendar](https://github.com/alan-turing-institute/research-engineering-group/wiki/Shared-REG-Calendar) to Outlook
 - [ ] Familiarise yourself with how to [Book Rooms]({{< relref "/docs/working_at_the_turing/booking_a_meeting_room.md" >}})
-- [ ] Message IT (ITServices@turing.ac.uk) to upgrade Zoom account from Basic to Pro
+- [ ] Message [IT](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact) to upgrade Zoom account from Basic to Pro
 - [ ] Send a short informal bio to the [REG newsletter owner](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#responsibilities).
 
 ## New computer set-up


### PR DESCRIPTION
<!--
Thank you for contributing!

Please use this pull request template to describe the changes you have made.

- Make sure that you give your pull request a meaningful title.
- If this work is not ready to merge yet, please make it a draft pull request.
- Make sure that your branch is up-to-date with main.
- There is no need to add labels to your pull request.
- You can assign particular reviewers if you want to, but there is no need to.

Note that text in html comments will not be rendered.
-->

## Summary
<!-- A clear and concise description of the changes. -->

This PR adds information about relocation and visa costs to the list of FAQs in the Handbook.

It also replaces some email addresses with a link to [The REGistry](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#points-of-contact).

## Related issues
<!--
If this pull request fixes any issues please list theme here, for example

- Closes #42
- Closes #237

If this pull request contributes to any issues without closing them please also
list them, for example

- Contributes to #42
- Contributes to #237

Note that if the issue is in a different repo, you will need to specify the full path
in the format OWNER/REPOSITORY#ISSUE-NUMBER, for example:

- Contributes to octo-org/octo-repo#100
-->

## Screenshots
<!-- If applicable, add screenshots to demonstrate explain your changes. -->

---

### Updates
<!--
Please update this initial comment with important updates (e.g. decisions taken).
-->

*Lorem ipsum dolor sit amet, consectetur adipiscing.*
