### PR TITLE
Updates links to request membership of Turing's GitHub Org

### DIFF
--- a/content/docs/onboarding/new_joiners/checklist.md
+++ b/content/docs/onboarding/new_joiners/checklist.md
@@ -62,7 +62,7 @@ If anything is unclear, please figure it out by e.g. asking your buddies, and th
 
 ## GitHub and communications
 
-- [ ] Get access to private GitHub repos (fill in [this form](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=3844fabf8b1c45ca9028758a350ff230) and send your GitHub username to the person responsible for GitHub (see [The REGistry](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#documents)) to join the Alan Turing Organisation GitHub
+- [ ] Get access to private GitHub repos (fill in [this form](https://forms.office.com/e/9rwSjBdfQp) and send your GitHub username to the person responsible for GitHub (see [The REGistry](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#documents)) to join the Alan Turing Organisation GitHub
 - [ ] Join Turing Slack
     - [ ] Go through public Slack channels, decide which ones to join
 - [ ] Request account on Harvest and Forecast by asking the the person in charge of researcher tool management, or your buddies to get you set up (to clarify, it is one account but allows you sign in to both) https://alan-turing-institute.github.io/REG-handbook/docs/onboarding/new_joiners/systems_set_up#harvest-and-forecast

--- a/content/docs/onboarding/new_joiners/systems_set_up.md
+++ b/content/docs/onboarding/new_joiners/systems_set_up.md
@@ -93,7 +93,7 @@ Important channels to join:
 
 We use GitHub for most coordination.
 
-To get access to [the Turing GitHub](https://github.com/alan-turing-institute), create a GitHub account (or use an existing one), then fill this form on [Turing Complete](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=3844fabf8b1c45ca9028758a350ff230) with your GitHub handle (if you have access to Turing Complete).
+To get access to Turing GitHub, create a GitHub account (or use an existing one), and fill out [this MS Form](https://forms.office.com/e/9rwSjBdfQp) with your GitHub handle (if you have access to Turing Complete).
 Then let [the GitHub org controller](https://github.com/alan-turing-institute/research-engineering-group/wiki/The-REGistry#responsibilities) know that you have done this and they can add you straight away.
 
 Also check the [Project tracker](https://github.com/alan-turing-institute/Hut23/projects/2?) to get a feeling on what goes on. We use it to track official projects we are tasked with. This is where we express preferences for projects, with emojis. Project leads should be assigned to the relevant issue and are responsible for keeping the issue up to date. Check [this section]({{< relref "/docs/how_we_work/project_tracking.md" >}}) of the handbook for more details.


### PR DESCRIPTION
## Summary
The form to request membership of the Turing GitHub Organisation has changed. This updates all of the references that could be found.

## Related issues
None

## Screenshots
None 


### Updates
None
