### PR TITLE
Add Open Source Policy

### DIFF
--- a/content/docs/how_we_work/open_source_policy.md
+++ b/content/docs/how_we_work/open_source_policy.md
@@ -14,13 +14,13 @@ weight: 2
 # Open Source Policy
 
 REG has a policy of publishing all the work we do under an open source licence, unless there are compelling reasons to make an exception.
-This typically means publishing software we write under one of the [OSI approved licences](https://opensource.org/licenses), or in the case of non-code contributions one of the [Creative Commons licences](https://creativecommons.org/share-your-work/).
+This typically means publishing software we write under one of the [OSI approved licences](https://opensource.org/licenses), or in the case of non-code contributions one of the [Creative Commons licences](https://creativecommons.org/share-your-work/) that supports derivative works.
 Our default choices are
 
-- [BSD 3-clause licence](https://opensource.org/license/BSD-3-clause) for permissive source code licencing.
-- [AGPL](https://www.gnu.org/licenses/agpl-3.0.en.html) for copyleft code licencing.
-- [CC-BY](https://creativecommons.org/licenses/by/4.0) for permissive licensing of non-code content.
-- [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/deed.en) for copyleft licensing of non-code content.
+- [BSD-3-Clause](https://opensource.org/license/BSD-3-clause) for permissive source code licencing.
+- [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0.en.html) for copyleft code licencing.
+- [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0) for permissive licensing of non-code content.
+- [CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en) for copyleft licensing of non-code content.
 
 However, these are only defaults, and we [choose a licence](https://choosealicense.com/) based on the needs of each project.
 
@@ -28,3 +28,6 @@ Open sourcing all our work is a strong default.
 We do make exceptions to it, but they need to be justified by some exceptional circumstance.
 The most typical case is working with a partner organisation and having to negotiate with them how to licence our joint work.
 In such cases we advocate for open sourcing the work to the greatest extent possible, but acknowledge that compromises may be necessary.
+
+A further case would be where upstream or integrated software imposes its own licensing restrictions that prevent open sourcing.
+We must always respect the licences of the code we use, whether open source or otherwise, but would also encourage the use of open source alternatives in such cases.

--- a/content/docs/how_we_work/open_source_policy.md
+++ b/content/docs/how_we_work/open_source_policy.md
@@ -17,10 +17,10 @@ REG has a policy of publishing all the work we do under an open source licence, 
 This typically means publishing software we write under one of the [OSI approved licences](https://opensource.org/licenses), or in the case of non-code contributions one of the [Creative Commons licences](https://creativecommons.org/share-your-work/).
 Our default choices are
 
-* [BSD 3-clause licence](https://opensource.org/license/BSD-3-clause) for permissive source code licencing.
-* [AGPL](https://www.gnu.org/licenses/agpl-3.0.en.html) for copyleft code licencing.
-* [CC-BY](https://creativecommons.org/licenses/by/4.0) for permissive licensing of non-code content.
-* [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/deed.en) for copyleft licensing of non-code content.
+- [BSD 3-clause licence](https://opensource.org/license/BSD-3-clause) for permissive source code licencing.
+- [AGPL](https://www.gnu.org/licenses/agpl-3.0.en.html) for copyleft code licencing.
+- [CC-BY](https://creativecommons.org/licenses/by/4.0) for permissive licensing of non-code content.
+- [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/deed.en) for copyleft licensing of non-code content.
 
 However, these are only defaults, and we [choose a licence](https://choosealicense.com/) based on the needs of each project.
 

--- a/content/docs/how_we_work/open_source_policy.md
+++ b/content/docs/how_we_work/open_source_policy.md
@@ -2,7 +2,7 @@
 # Page title as it appears in the navigation menu
 title: "Open Source Policy"
 # Adjust weight to reorder menu items (lower numbers appear first)
-weight: 2
+weight: 6
 # Uncomment to hide nested pages in a collapsed menu
 # bookCollapseSection = true
 # Uncomment to hide this page from the navigation menu

--- a/content/docs/how_we_work/open_source_policy.md
+++ b/content/docs/how_we_work/open_source_policy.md
@@ -1,0 +1,23 @@
+---
+# Page title as it appears in the navigation menu
+title: "Open Source Policy"
+# Adjust weight to reorder menu items (lower numbers appear first)
+weight: 2
+# Uncomment to hide nested pages in a collapsed menu
+# bookCollapseSection = true
+# Uncomment to hide this page from the navigation menu
+# bookHidden = false
+# Uncomment to exclude this page from the search
+# bookSearchExclude = true
+---
+
+# Open Source Policy
+
+REG has a policy of publishing all the work we do under an open source licence, unless there are compelling reasons to make an exception.
+This typically means publishing software we write under one of the [OSI approved licences](https://opensource.org/licenses), or in the case of non-code contributions one of the [Creative Commons licences](https://creativecommons.org/share-your-work/).
+Our default choices are the [BSD 3-clause licence](https://opensource.org/license/BSD-3-clause) for permissive source code licencing, [AGPL](https://www.gnu.org/licenses/agpl-3.0.en.html) for copyleft code licencing, and [CC-BY](https://creativecommons.org/licenses/by/4.0) or [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/deed.en) for non-code content, but we make a choice based on the needs of the project.
+
+Open sourcing all our work is a strong default.
+We do make exceptions to it, but they need to be justified by some exceptional circumstance.
+The most typical case is working with a partner organisation and having to negotiate with them how to licence our joint work.
+In such cases we advocate for open sourcing the work to the greatest extent possible, but acknowledge that compromises may be necessary.

--- a/content/docs/how_we_work/open_source_policy.md
+++ b/content/docs/how_we_work/open_source_policy.md
@@ -15,7 +15,14 @@ weight: 2
 
 REG has a policy of publishing all the work we do under an open source licence, unless there are compelling reasons to make an exception.
 This typically means publishing software we write under one of the [OSI approved licences](https://opensource.org/licenses), or in the case of non-code contributions one of the [Creative Commons licences](https://creativecommons.org/share-your-work/).
-Our default choices are the [BSD 3-clause licence](https://opensource.org/license/BSD-3-clause) for permissive source code licencing, [AGPL](https://www.gnu.org/licenses/agpl-3.0.en.html) for copyleft code licencing, and [CC-BY](https://creativecommons.org/licenses/by/4.0) or [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/deed.en) for non-code content, but we make a choice based on the needs of the project.
+Our default choices are
+
+* [BSD 3-clause licence](https://opensource.org/license/BSD-3-clause) for permissive source code licencing.
+* [AGPL](https://www.gnu.org/licenses/agpl-3.0.en.html) for copyleft code licencing.
+* [CC-BY](https://creativecommons.org/licenses/by/4.0) for permissive licensing of non-code content.
+* [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/deed.en) for copyleft licensing of non-code content.
+
+However, these are only defaults, and we [choose a licence](https://choosealicense.com/) based on the needs of each project.
 
 Open sourcing all our work is a strong default.
 We do make exceptions to it, but they need to be justified by some exceptional circumstance.

--- a/content/docs/how_we_work/open_source_policy.md
+++ b/content/docs/how_we_work/open_source_policy.md
@@ -15,7 +15,7 @@ weight: 2
 
 REG has a policy of publishing all the work we do under an open source licence, unless there are compelling reasons to make an exception.
 This typically means publishing software we write under one of the [OSI approved licences](https://opensource.org/licenses), or in the case of non-code contributions one of the [Creative Commons licences](https://creativecommons.org/share-your-work/) that supports derivative works.
-Our default choices are
+Our default choices are:
 
 - [BSD-3-Clause](https://opensource.org/license/BSD-3-clause) for permissive source code licencing.
 - [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0.en.html) for copyleft code licencing.
@@ -26,7 +26,7 @@ However, these are only defaults, and we [choose a licence](https://choosealicen
 
 Open sourcing all our work is a strong default.
 We do make exceptions to it, but they need to be justified by some exceptional circumstance.
-The most typical case is working with a partner organisation and having to negotiate with them how to licence our joint work.
+The most typical case is working with a partner organisation and having to negotiate with them how to license our joint work.
 In such cases we advocate for open sourcing the work to the greatest extent possible, but acknowledge that compromises may be necessary.
 
 A further case would be where upstream or integrated software imposes its own licensing restrictions that prevent open sourcing.


### PR DESCRIPTION
REG has a de facto policy of open sourcing our work when possible, and advocating for open sourcing projects that we are a part of. Over at the Open Source Service Area, we think it would be good to have this written down somewhere. The handbook seems like the natural place. I wrote a draft, which I think essentially codifies what we already do. Please give comments. An approval from @martintoreilly in particular would be welcome.

Cc @rwood-97, @llewelld.