### PR TITLE
Update Lunchtime Tech Talks schedule time and links

### DIFF
--- a/content/docs/regular_events/lunchtime_tech_talks.md
+++ b/content/docs/regular_events/lunchtime_tech_talks.md
@@ -14,11 +14,11 @@ weight: 10
 # Lunchtime Tech Talks
 
 The Research Engineering team meets for Lunchtime Tech Talks most Tuesdays over lunch.
-The talks start at 12:30.
+The talks start at 13:00.
 
 At a tech talk someone (usually someone in REG) presents or discusses something, such as about a project or data science/computer science/software engineering topic.
 They can also be opportunities to look for help and input.
 We encourage talks at the beginning of projects (before it's certain what exactly you'll be doing) or to discuss a problem you're unsure how to solve.
 We also have shorter format [lightning talks]({{< relref "docs/regular_events/lightning_talks.md" >}}), where several people give a shorter talk.
 
-[The Data Science Skills wiki](https://github.com/alan-turing-institute/DataScienceSkills/wiki/Lunchtime-Tech-Talks) contains the talks schedule, calendar invitation instructions and information on signing up for a talk.
+[REG Knowledge Sharing wiki](https://github.com/alan-turing-institute/REG-knowledge-sharing/wiki/Lunchtime-Tech-Talks) contains the talks schedule, calendar invitation instructions and information on signing up for a talk.


### PR DESCRIPTION
Updating the time for tech talks, and link to the new github page and wiki.

